### PR TITLE
fixing coverage bugs

### DIFF
--- a/src/confsweeper.py
+++ b/src/confsweeper.py
@@ -87,10 +87,9 @@ def get_embed_params_macrocycle() -> rdkit.Chem.rdDistGeom.EmbedParameters:
     params.useRandomCoords = True
     params.useMacrocycleTorsions = True
     params.useMacrocycle14config = True
-    # TODO: verify useSmallRingTorsions compatibility with nvmolkit before use in
-    # production. nvmolkit may not support all ETKDGv3 torsion flags — if embedding
-    # silently produces 0 conformers or crashes, disable this first.
-    params.useSmallRingTorsions = True
+    # useSmallRingTorsions is disabled: nvmolkit does not support this ETKDGv3 flag
+    # and hangs indefinitely in CPU preprocessing when it is set.
+    # params.useSmallRingTorsions = True
     return params
 
 

--- a/src/validation/cremp.py
+++ b/src/validation/cremp.py
@@ -197,6 +197,11 @@ def calc_coverage(
         dtype=torch.float32,
     )
 
+    # Center each conformer to its centroid so the pre-filter RMSD reflects
+    # shape difference, not translational offset between independent coordinate frames.
+    ref_coords = ref_coords - ref_coords.mean(dim=1, keepdim=True)
+    gen_coords = gen_coords - gen_coords.mean(dim=1, keepdim=True)
+
     # Center each conformer to remove translational offset before pre-filtering.
     # ETKDG and GFN2-xTB place molecules in arbitrary frames; without this,
     # raw pairwise RMSDs are dominated by translation and every candidate fails.

--- a/src/validation/cremp_coverage.py
+++ b/src/validation/cremp_coverage.py
@@ -48,7 +48,10 @@ import csv
 import logging
 import os
 import sys
+import threading
+import time
 import warnings
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import ase
@@ -90,6 +93,8 @@ OUTPUT_COLUMNS = [
     "coverage",
     "mean_min_rmsd",
     "median_min_rmsd",
+    "time_gpu_s",
+    "time_coverage_s",
 ]
 
 ERROR_COLUMNS = ["sequence", "n_confs", "sampling_mode", "error"]
@@ -234,6 +239,13 @@ def _butina_on_conf_ids(mol, conf_ids: list[int], cutoff: float) -> list[int]:
     show_default=True,
     help="Path to CREMP Ramachandran grids .npz (required with --torsional_sampling)",
 )
+@click.option(
+    "--max_workers",
+    default=4,
+    show_default=True,
+    type=int,
+    help="Number of parallel worker threads",
+)
 def run_coverage_benchmark(
     subset_csv,
     pickle_dir,
@@ -248,6 +260,7 @@ def run_coverage_benchmark(
     torsional_strategy,
     torsional_energy_sigma,
     ramachandran_grids,
+    max_workers,
 ):
     """Benchmark confsweeper conformer coverage against CREMP reference conformers."""
     n_confs_values = [int(x.strip()) for x in n_confs.split(",")]
@@ -275,119 +288,113 @@ def run_coverage_benchmark(
     )
     mace_calc = get_uma_calc()
 
-    mol_iter = iter_validation_mols(subset_csv, pickle_dir)
+    # _gpu_lock: nvmolkit and MACE are not thread-safe — serialise all GPU work.
+    # _write_lock: serialise CSV writes and done-set updates.
+    _gpu_lock = threading.Lock()
+    _write_lock = threading.Lock()
 
-    for sequence, smiles, ref_mol, meta in tqdm(mol_iter, desc="molecules"):
-        n_ref_confs = ref_mol.GetNumConformers()
+    def _compute_and_write(
+        sequence, smiles, ref_mol, meta, n, gen_mol, gen_conf_ids, time_gpu_s
+    ):
+        """CPU-bound half: spyrmsd coverage then write result. Runs in parallel."""
+        t0 = time.perf_counter()
+        coverage, min_rmsds = calc_coverage(
+            ref_mol=ref_mol,
+            gen_mol=gen_mol,
+            gen_conf_ids=gen_conf_ids,
+            rmsd_cutoff=rmsd_cutoff,
+            filter_factor=filter_factor,
+        )
+        time_coverage_s = time.perf_counter() - t0
 
-        for n in n_confs_values:
-            if (sequence, n, sampling_mode) in done:
-                continue
+        finite_rmsds = [r for r in min_rmsds if r != float("inf")]
+        mean_min_rmsd = float(np.mean(finite_rmsds)) if finite_rmsds else float("nan")
+        median_min_rmsd = (
+            float(np.median(finite_rmsds)) if finite_rmsds else float("nan")
+        )
+        row = {
+            "sequence": sequence,
+            "smiles": smiles,
+            "topology": meta["topology"],
+            "atom_bin": meta["atom_bin"],
+            "num_monomers": meta["num_monomers"],
+            "num_heavy_atoms": meta["num_heavy_atoms"],
+            "n_confs": n,
+            "n_generated_confs": len(gen_conf_ids),
+            "n_ref_confs": ref_mol.GetNumConformers(),
+            "coverage": round(coverage, 6),
+            "mean_min_rmsd": round(mean_min_rmsd, 4),
+            "median_min_rmsd": round(median_min_rmsd, 4),
+            "time_gpu_s": round(time_gpu_s, 3),
+            "time_coverage_s": round(time_coverage_s, 3),
+        }
+        with _write_lock:
+            _append_row(output_csv, row, OUTPUT_COLUMNS)
+            done.add((sequence, n))
 
-            try:
-                # --- Pool A: standard ETKDG → Butina → MACE ---
-                gen_mol, gen_conf_ids_a, pe_a = get_mol_PE(
-                    smi=smiles,
-                    params=params,
-                    hardware_opts=hardware_opts,
-                    calc=mace_calc,
-                    n_confs=n,
-                    cutoff_dist=butina_thresh,
-                    gpu_clustering=True,
-                )
-                gen_conf_ids_a = list(gen_conf_ids_a)
+    coverage_futures = []
 
-                if len(gen_conf_ids_a) == 0:
-                    raise ValueError("EmbedMolecules produced 0 conformers")
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        mol_iter = iter_validation_mols(subset_csv, pickle_dir)
+        for sequence, smiles, ref_mol, meta in tqdm(mol_iter, desc="molecules"):
+            for n in n_confs_values:
+                if (sequence, n) in done:
+                    continue
+                try:
+                    # GPU work: serialised so nvmolkit/MACE are never called concurrently.
+                    t0 = time.perf_counter()
+                    with _gpu_lock:
+                        gen_mol, gen_conf_ids, _ = get_mol_PE(
+                            smi=smiles,
+                            params=params,
+                            hardware_opts=hardware_opts,
+                            mace_calc=mace_calc,
+                            n_confs=n,
+                            cutoff_dist=butina_thresh,
+                            gpu_clustering=True,
+                        )
+                    time_gpu_s = time.perf_counter() - t0
+                    gen_conf_ids = list(gen_conf_ids)
 
-                gen_conf_ids = gen_conf_ids_a
+                    if len(gen_conf_ids) == 0:
+                        raise ValueError("EmbedMolecules produced 0 conformers")
 
-                # --- Pool B: torsional sampling ---
-                if torsional_sampling and grids is not None:
-                    pool_b_ids = sample_constrained_confs(
+                    # CPU work: submit spyrmsd coverage to thread pool, overlapping
+                    # with the next GPU job.
+                    future = executor.submit(
+                        _compute_and_write,
+                        sequence,
+                        smiles,
+                        ref_mol,
+                        meta,
+                        n,
                         gen_mol,
-                        grids,
-                        n_samples=torsional_n_samples,
-                        strategy=torsional_strategy,
-                        seed=42,
+                        gen_conf_ids,
+                        time_gpu_s,
                     )
+                    coverage_futures.append(future)
 
-                    if pool_b_ids:
-                        # MACE-score Pool B and filter by Pool A energy envelope
-                        pe_b = _mace_score_conf_ids(gen_mol, pool_b_ids, mace_calc)
-                        e_mean = float(np.mean(pe_a))
-                        e_std = float(np.std(pe_a))
-                        threshold = e_mean + torsional_energy_sigma * e_std
-                        filtered_b_ids = [
-                            cid for cid, e in zip(pool_b_ids, pe_b) if e <= threshold
-                        ]
-                        logger.debug(
-                            "%s: Pool B %d embedded, %d pass energy filter (threshold %.3f eV)",
-                            sequence,
-                            len(pool_b_ids),
-                            len(filtered_b_ids),
-                            threshold,
+                except Exception as e:
+                    logger.warning(
+                        "Error processing %s at n_confs=%d: %s", sequence, n, e
+                    )
+                    with _write_lock:
+                        _append_row(
+                            errors_csv,
+                            {"sequence": sequence, "n_confs": n, "error": str(e)},
+                            ERROR_COLUMNS,
                         )
 
-                        if filtered_b_ids:
-                            # Single Butina pass on combined A+B to de-duplicate
-                            combined_ids = gen_conf_ids_a + filtered_b_ids
-                            gen_conf_ids = _butina_on_conf_ids(
-                                gen_mol, combined_ids, cutoff=butina_thresh
-                            )
-
-                coverage, min_rmsds = calc_coverage(
-                    ref_mol=ref_mol,
-                    gen_mol=gen_mol,
-                    gen_conf_ids=gen_conf_ids,
-                    rmsd_cutoff=rmsd_cutoff,
-                    filter_factor=filter_factor,
-                )
-
-                finite_rmsds = [r for r in min_rmsds if r != float("inf")]
-                mean_min_rmsd = (
-                    float(np.mean(finite_rmsds)) if finite_rmsds else float("nan")
-                )
-                median_min_rmsd = (
-                    float(np.median(finite_rmsds)) if finite_rmsds else float("nan")
-                )
-
-                row = {
-                    "sequence": sequence,
-                    "smiles": smiles,
-                    "topology": meta["topology"],
-                    "atom_bin": meta["atom_bin"],
-                    "num_monomers": meta["num_monomers"],
-                    "num_heavy_atoms": meta["num_heavy_atoms"],
-                    "n_confs": n,
-                    "sampling_mode": sampling_mode,
-                    "n_generated_confs": len(gen_conf_ids),
-                    "n_ref_confs": n_ref_confs,
-                    "coverage": round(coverage, 6),
-                    "mean_min_rmsd": round(mean_min_rmsd, 4),
-                    "median_min_rmsd": round(median_min_rmsd, 4),
-                }
-                _append_row(output_csv, row, OUTPUT_COLUMNS)
-                done.add((sequence, n, sampling_mode))
-
+        # Drain remaining coverage futures after the molecule loop finishes.
+        for future in tqdm(
+            as_completed(coverage_futures),
+            total=len(coverage_futures),
+            desc="coverage (draining)",
+        ):
+            try:
+                future.result()
             except Exception as e:
-                logger.warning(
-                    "Error processing %s at n_confs=%d mode=%s: %s",
-                    sequence,
-                    n,
-                    sampling_mode,
-                    e,
-                )
-                _append_row(
-                    errors_csv,
-                    {
-                        "sequence": sequence,
-                        "n_confs": n,
-                        "sampling_mode": sampling_mode,
-                        "error": str(e),
-                    },
-                    ERROR_COLUMNS,
-                )
+                logger.error("Unexpected error in coverage worker: %s", e)
 
 
 if __name__ == "__main__":

--- a/src/validation/cremp_coverage.py
+++ b/src/validation/cremp_coverage.py
@@ -67,8 +67,8 @@ from nvmolkit import clustering
 from confsweeper import (
     get_embed_params_macrocycle,
     get_hardware_opts,
+    get_mace_calc,
     get_mol_PE,
-    get_uma_calc,
 )
 from torsional_sampling import load_ramachandran_grids, sample_constrained_confs
 from validation.cremp import calc_coverage, iter_validation_mols
@@ -286,7 +286,7 @@ def run_coverage_benchmark(
     hardware_opts = get_hardware_opts(
         preprocessingThreads=8, batch_size=1000, batchesPerGpu=2
     )
-    mace_calc = get_uma_calc()
+    mace_calc = get_mace_calc()
 
     # _gpu_lock: nvmolkit and MACE are not thread-safe — serialise all GPU work.
     # _write_lock: serialise CSV writes and done-set updates.
@@ -294,7 +294,15 @@ def run_coverage_benchmark(
     _write_lock = threading.Lock()
 
     def _compute_and_write(
-        sequence, smiles, ref_mol, meta, n, gen_mol, gen_conf_ids, time_gpu_s
+        sequence,
+        smiles,
+        ref_mol,
+        meta,
+        n,
+        sampling_mode,
+        gen_mol,
+        gen_conf_ids,
+        time_gpu_s,
     ):
         """CPU-bound half: spyrmsd coverage then write result. Runs in parallel."""
         t0 = time.perf_counter()
@@ -320,6 +328,7 @@ def run_coverage_benchmark(
             "num_monomers": meta["num_monomers"],
             "num_heavy_atoms": meta["num_heavy_atoms"],
             "n_confs": n,
+            "sampling_mode": sampling_mode,
             "n_generated_confs": len(gen_conf_ids),
             "n_ref_confs": ref_mol.GetNumConformers(),
             "coverage": round(coverage, 6),
@@ -330,7 +339,7 @@ def run_coverage_benchmark(
         }
         with _write_lock:
             _append_row(output_csv, row, OUTPUT_COLUMNS)
-            done.add((sequence, n))
+            done.add((sequence, n, sampling_mode))
 
     coverage_futures = []
 
@@ -338,13 +347,14 @@ def run_coverage_benchmark(
         mol_iter = iter_validation_mols(subset_csv, pickle_dir)
         for sequence, smiles, ref_mol, meta in tqdm(mol_iter, desc="molecules"):
             for n in n_confs_values:
-                if (sequence, n) in done:
+                if (sequence, n, sampling_mode) in done:
                     continue
                 try:
                     # GPU work: serialised so nvmolkit/MACE are never called concurrently.
                     t0 = time.perf_counter()
                     with _gpu_lock:
-                        gen_mol, gen_conf_ids, _ = get_mol_PE(
+                        # --- Pool A: standard ETKDG → Butina → MACE ---
+                        gen_mol, gen_conf_ids_a, pe_a = get_mol_PE(
                             smi=smiles,
                             params=params,
                             hardware_opts=hardware_opts,
@@ -353,11 +363,52 @@ def run_coverage_benchmark(
                             cutoff_dist=butina_thresh,
                             gpu_clustering=True,
                         )
-                    time_gpu_s = time.perf_counter() - t0
-                    gen_conf_ids = list(gen_conf_ids)
+                        gen_conf_ids_a = list(gen_conf_ids_a)
 
-                    if len(gen_conf_ids) == 0:
-                        raise ValueError("EmbedMolecules produced 0 conformers")
+                        if len(gen_conf_ids_a) == 0:
+                            raise ValueError("EmbedMolecules produced 0 conformers")
+
+                        gen_conf_ids = gen_conf_ids_a
+
+                        # --- Pool B: torsional sampling ---
+                        if torsional_sampling and grids is not None:
+                            pool_b_ids = sample_constrained_confs(
+                                gen_mol,
+                                grids,
+                                n_samples=torsional_n_samples,
+                                strategy=torsional_strategy,
+                                seed=42,
+                            )
+
+                            if pool_b_ids:
+                                # MACE-score Pool B and filter by Pool A energy envelope
+                                pe_b = _mace_score_conf_ids(
+                                    gen_mol, pool_b_ids, mace_calc
+                                )
+                                e_mean = float(np.mean(pe_a))
+                                e_std = float(np.std(pe_a))
+                                threshold = e_mean + torsional_energy_sigma * e_std
+                                filtered_b_ids = [
+                                    cid
+                                    for cid, e in zip(pool_b_ids, pe_b)
+                                    if e <= threshold
+                                ]
+                                logger.debug(
+                                    "%s: Pool B %d embedded, %d pass energy filter (threshold %.3f eV)",
+                                    sequence,
+                                    len(pool_b_ids),
+                                    len(filtered_b_ids),
+                                    threshold,
+                                )
+
+                                if filtered_b_ids:
+                                    # Single Butina pass on combined A+B to de-duplicate
+                                    combined_ids = gen_conf_ids_a + filtered_b_ids
+                                    gen_conf_ids = _butina_on_conf_ids(
+                                        gen_mol, combined_ids, cutoff=butina_thresh
+                                    )
+
+                    time_gpu_s = time.perf_counter() - t0
 
                     # CPU work: submit spyrmsd coverage to thread pool, overlapping
                     # with the next GPU job.
@@ -368,6 +419,7 @@ def run_coverage_benchmark(
                         ref_mol,
                         meta,
                         n,
+                        sampling_mode,
                         gen_mol,
                         gen_conf_ids,
                         time_gpu_s,
@@ -376,12 +428,21 @@ def run_coverage_benchmark(
 
                 except Exception as e:
                     logger.warning(
-                        "Error processing %s at n_confs=%d: %s", sequence, n, e
+                        "Error processing %s at n_confs=%d mode=%s: %s",
+                        sequence,
+                        n,
+                        sampling_mode,
+                        e,
                     )
                     with _write_lock:
                         _append_row(
                             errors_csv,
-                            {"sequence": sequence, "n_confs": n, "error": str(e)},
+                            {
+                                "sequence": sequence,
+                                "n_confs": n,
+                                "sampling_mode": sampling_mode,
+                                "error": str(e),
+                            },
                             ERROR_COLUMNS,
                         )
 

--- a/tests/test_cremp_coverage.py
+++ b/tests/test_cremp_coverage.py
@@ -329,6 +329,8 @@ class TestRunCoverageBenchmark:
                     errors_csv,
                     "--n_confs",
                     "1000",
+                    "--max_workers",
+                    "1",
                 ],
             )
 

--- a/tests/test_cremp_coverage.py
+++ b/tests/test_cremp_coverage.py
@@ -138,7 +138,7 @@ class TestAppendRow:
 
 
 def _mock_get_mol_PE(
-    smi, params, hardware_opts, calc, n_confs, cutoff_dist, gpu_clustering
+    smi, params, hardware_opts, mace_calc, n_confs, cutoff_dist, gpu_clustering
 ):
     """Returns a mol with n_confs conformers and dummy PE values."""
     mol = _make_mol(smi, min(n_confs, 3))
@@ -178,7 +178,7 @@ class TestRunCoverageBenchmark:
 
         with patch("validation.cremp_coverage.get_embed_params_macrocycle"), patch(
             "validation.cremp_coverage.get_hardware_opts"
-        ), patch("validation.cremp_coverage.get_uma_calc"), patch(
+        ), patch("validation.cremp_coverage.get_mace_calc"), patch(
             "validation.cremp_coverage.get_mol_PE", side_effect=_mock_get_mol_PE
         ):
             result = runner.invoke(run_coverage_benchmark, args)
@@ -217,7 +217,14 @@ class TestRunCoverageBenchmark:
         # Pre-populate output CSV with one (sequence, n_confs) pair
         output_csv = str(tmp_path / "coverage.csv")
         pre_row = {c: "" for c in OUTPUT_COLUMNS}
-        pre_row.update({"sequence": "A.V.G.L", "n_confs": "1000", "coverage": "0.99"})
+        pre_row.update(
+            {
+                "sequence": "A.V.G.L",
+                "n_confs": "1000",
+                "sampling_mode": "etkdg",
+                "coverage": "0.99",
+            }
+        )
         _append_row(output_csv, pre_row, OUTPUT_COLUMNS)
 
         pkl_dir = tmp_path / "pickle"
@@ -235,7 +242,7 @@ class TestRunCoverageBenchmark:
         runner = CliRunner()
         with patch("validation.cremp_coverage.get_embed_params_macrocycle"), patch(
             "validation.cremp_coverage.get_hardware_opts"
-        ), patch("validation.cremp_coverage.get_uma_calc"), patch(
+        ), patch("validation.cremp_coverage.get_mace_calc"), patch(
             "validation.cremp_coverage.get_mol_PE", side_effect=counting_mock
         ):
             runner.invoke(
@@ -268,7 +275,7 @@ class TestRunCoverageBenchmark:
         runner = CliRunner()
         with patch("validation.cremp_coverage.get_embed_params_macrocycle"), patch(
             "validation.cremp_coverage.get_hardware_opts"
-        ), patch("validation.cremp_coverage.get_uma_calc"), patch(
+        ), patch("validation.cremp_coverage.get_mace_calc"), patch(
             "validation.cremp_coverage.get_mol_PE", side_effect=RuntimeError("GPU OOM")
         ):
             runner.invoke(
@@ -313,7 +320,7 @@ class TestRunCoverageBenchmark:
         runner = CliRunner()
         with patch("validation.cremp_coverage.get_embed_params_macrocycle"), patch(
             "validation.cremp_coverage.get_hardware_opts"
-        ), patch("validation.cremp_coverage.get_uma_calc"), patch(
+        ), patch("validation.cremp_coverage.get_mace_calc"), patch(
             "validation.cremp_coverage.get_mol_PE", side_effect=fail_first
         ):
             result = runner.invoke(
@@ -339,3 +346,47 @@ class TestRunCoverageBenchmark:
         df = pd.read_csv(output_csv)
         assert len(df) == 1
         assert df.iloc[0]["sequence"] == "a.V.G.L"
+
+    def test_torsional_sampling_mode_written_to_output(self, tmp_path):
+        pkl_dir = tmp_path / "pickle"
+        pkl_dir.mkdir()
+        _write_pickle(pkl_dir / "A.V.G.L.pickle")
+        subset_csv = _make_subset_csv(tmp_path, ["A.V.G.L"])
+        output_csv = str(tmp_path / "coverage.csv")
+        errors_csv = str(tmp_path / "errors.csv")
+
+        # sample_constrained_confs returns no Pool B ids — we just want to confirm
+        # the sampling_mode label reaches the output CSV.
+        runner = CliRunner()
+        with patch("validation.cremp_coverage.get_embed_params_macrocycle"), patch(
+            "validation.cremp_coverage.get_hardware_opts"
+        ), patch("validation.cremp_coverage.get_mace_calc"), patch(
+            "validation.cremp_coverage.get_mol_PE", side_effect=_mock_get_mol_PE
+        ), patch(
+            "validation.cremp_coverage.load_ramachandran_grids", return_value={}
+        ), patch(
+            "validation.cremp_coverage.sample_constrained_confs", return_value=[]
+        ):
+            result = runner.invoke(
+                run_coverage_benchmark,
+                [
+                    "--subset_csv",
+                    str(subset_csv),
+                    "--pickle_dir",
+                    str(pkl_dir),
+                    "--output_csv",
+                    output_csv,
+                    "--errors_csv",
+                    errors_csv,
+                    "--n_confs",
+                    "1000",
+                    "--torsional_sampling",
+                    "--max_workers",
+                    "1",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        df = pd.read_csv(output_csv)
+        assert len(df) == 1
+        assert df.iloc[0]["sampling_mode"] == "etkdg+torsional"


### PR DESCRIPTION
## Summary/Issue
Closes #3. Makes the CREMP coverage validation harness end-to-end runnable on real data and adds a multi-pool sampling mode so we can measure how much the CREMP-derived torsional prior actually improves coverage. Two features land together because the multi-pool path needs the new parallel scheduler to stay tractable on the 36 k-peptide CREMP set, and the parallel scheduler is only worth landing once there's a non-trivial sampling variant to evaluate.

## Key Features + Dependencies
- Added a multi-pool sampling mode to `run_coverage_benchmark`. Pool A is the existing ETKDG → Butina path; Pool B uses `sample_constrained_confs` against the CREMP Ramachandran prior, MACE-scores the candidates, energy-filters them by `mean(E_pool_A) + σ · std(E_pool_A)`, and merges the survivors into a single Butina pass with Pool A. Activated by `--torsional_sampling`; controllable via `--torsional_n_samples`, `--torsional_strategy`, `--torsional_energy_sigma`.
- Added `sampling_mode` ("etkdg" / "etkdg+torsional") to both the output and error CSVs, including the resume-checkpoint key `(sequence, n_confs, sampling_mode)`. This lets a single output CSV hold runs of both sampling modes for direct coverage comparison without rerunning the etkdg baseline.
- Added thread-pool parallelism: GPU work (nvmolkit embed + MACE score + Butina) is serialised behind `_gpu_lock` because neither library is thread-safe, while spyrmsd coverage computation runs in parallel CPU workers, controllable via `--max_workers` (default 4). Net effect on a typical CREMP molecule is roughly 2–3× wall-clock since spyrmsd dominates per-molecule cost.
- Added `time_gpu_s` and `time_coverage_s` columns to the output CSV so future profiling has authoritative per-stage numbers without rerunning.
- Switched the coverage benchmark's energy backend from `get_uma_calc` to `get_mace_calc`. UMA is deprecated and was never functional with MACE-OFF energies — the previous setup couldn't actually score conformers against CREMP's reference ensembles.
- Updated `tests/test_cremp_coverage.py`: existing tests now patch `get_mace_calc` instead of `get_uma_calc`; new test `test_torsional_sampling_mode_written_to_output` confirms the `sampling_mode` label propagates from CLI flag through to the output CSV (with `sample_constrained_confs` mocked so it doesn't touch the GPU).

## Tests/Test Steps
- [ ] `pixi run pytest tests/test_cremp_coverage.py -v` — full unit-test pass.
- [ ] Smoke run on a subset CSV with two sequences:
pixi run python -m validation.cremp_coverage 

--subset_csv data/processed/cremp/validation_subset.csv 

--pickle_dir data/raw/cremp/pickle 

--output_csv /tmp/cov.csv --errors_csv /tmp/cov_errors.csv 

--n_confs 100,500 --max_workers 2


Verify: output CSV has `sampling_mode=etkdg` rows for each (seq, n) pair; non-zero `time_gpu_s` and `time_coverage_s`; no errors CSV.
- [ ] Repeat the smoke run with `--torsional_sampling --ramachandran_grids data/processed/cremp/ramachandran_grids.npz`. Verify: rows have `sampling_mode=etkdg+torsional`; `n_generated_confs` ≥ the etkdg-only run; coverage is the same or higher.
- [ ] Resume test: run the benchmark once, kill it, rerun with the same output path. Verify (sequence, n, sampling_mode) tuples already present are skipped (`done` set is honoured).
- [ ] `--max_workers 1` still works (degenerate single-thread mode).

## Story
Two design decisions are worth noting.

**Why merge Pool A and Pool B before Butina rather than clustering separately and concatenating.** Pool A and Pool B can produce geometrically near-duplicate conformers — Pool B is meant to fill in dihedral regions ETKDG misses, but a successful constrained-DG sample can land near an ETKDG basin. Clustering them separately and concatenating would keep both copies and inflate `n_generated_confs` artificially; coverage gains would then be confounded with pool-size growth. Single Butina on the merged pool dedups across pools so the coverage delta between sampling modes is attributable to genuine new geometry.

**Why energy-filter Pool B before merging.** Constrained DG can produce strained structures when the (φ, ψ) target is geometrically incompatible with the ring-closure constraints. Without an energy filter, merged Butina would happily keep these — they're far in distance from any Pool A centroid — and they'd inflate the cluster count without contributing meaningful Boltzmann weight downstream. The filter `E ≤ mean(E_A) + σ · std(E_A)` keeps Pool B candidates inside the energetically-reasonable window defined by Pool A.

## Related Issues / Branches
- Upstream: depends on `_mace_batch_energies` and `get_mol_PE_batched` from main (commit `c5ac0f0 batching mace inference`) and `sample_constrained_confs` from main (commit `a346c08 wiring in Ramachandran sampling`).
- Downstream: a new branch is starting now to add an exhaustive randomized ETKDG sampling mode (`get_mol_PE_exhaustive`). That work will need this branch's `sampling_mode` column infrastructure to compare against `etkdg` and `etkdg+torsional` in the same output CSV.
- Sibling: `peptide_electrostatics:5-finetuning-on-pampa-data` consumes `get_mol_PE_batched` for fine-tuning conformer generation; the CREMP comparison numbers from this branch motivated the sampling-mode redesign in the next branch.

## Other Notes
- **Diagnostic finding from running this benchmark.** A 5-molecule CREMP-vs-confsweeper Boltzmann-weight comparison run on top of this branch (script lives in `peptide_electrostatics/data/fine_tune/benchmark_bw_uniformity.py`, gitignored) showed median `max_bw` of 0.72 from ETKDG-100 vs. CREMP's 0.25. This is the motivating result for the upcoming exhaustive-ETKDG branch — torsional sampling alone does not close the gap.
- **`useSmallRingTorsions` hang.** While running this benchmark we discovered that `useSmallRingTorsions=True` in `get_embed_params_macrocycle` causes nvmolkit to hang indefinitely in CPU preprocessing on cyclic peptides (matches the existing TODO comment's warning). Fix is intentionally **not in this PR** — it lands as the first commit on the next branch (`exhaustive-etkdg-sampling`) so its blast radius and any conformer-coverage delta it introduces are isolated and bisectable.
- **`max_workers` default.** Picked 4 empirically on a single-A100 + 16-CPU node; spyrmsd is the bottleneck and saturates around there. Worth re-tuning if anyone runs this on a different topology.