### PR TITLE
Randomized ETKDG Sampling Benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .pixi/*
 !.pixi/config.toml
 
+# Diagnostic script logs (kept locally for monitoring; not tracked)
+scripts/*.log
+
 # Docs
 .cache/
 docs/reference/*

--- a/docs/exhaustive_etkdg_plan.md
+++ b/docs/exhaustive_etkdg_plan.md
@@ -1,0 +1,327 @@
+# Exhaustive randomized ETKDG — design plan
+
+Branch: `7-randomized-etkdg-sampling`. Closes #7.
+
+This document is the working design for a new sampling mode in confsweeper that
+replaces CREST metadynamics with brute-force randomized ETKDG. It captures the
+motivating data, the planned pipeline, and the experimental findings that
+inform the implementation. Folded into `src/README.md` (or deleted) before the
+PR ships.
+
+---
+
+## Background
+
+The current `get_mol_PE_batched` runs nvmolkit ETKDG at `n_confs=100` and
+optionally a Pool B torsional sampler, then clusters with Butina at
+`cutoff_dist=0.1`. The design intent is to provide a CREST-replacement for
+cyclic peptides where exhaustive metadynamics is too expensive.
+
+A direct CREMP comparison run on the deduplicated CycPeptMPDB PAMPA dataset
+shows the current pipeline severely under-samples. CREMP (CREST-generated
+ensembles, 36 198 macrocyclic peptides) is the natural ground truth here:
+
+| metric | CREMP (CREST) | confsweeper (ETKDG, n_confs=100) |
+|---|---|---|
+| median Boltzmann weight of dominant conformer | 25.4 % | ≈ 72 % |
+| peptides with `max_bw > 0.95` | 0.4 % | majority |
+| mean unique conformers per peptide | 864 | 100 (only ~3 within 3 kT) |
+
+A Butina cutoff sweep (0.1 → 0.01) on a representative PAMPA peptide kept all
+100 conformers as their own clusters at every cutoff. Clustering is therefore
+**not** the bottleneck — sampling diversity is. CREMP shows the underlying
+macrocyclic-peptide landscape is generally not one-hot, so the sharpness we
+observe is purely an artifact of ETKDG-100 finding one basin per molecule.
+
+This impacts the PAMPA fine-tuning val/MAE directly: only one conformer per
+molecule contributes to the property prediction. The fine-tuning wrapper had
+to be initialised at α = 0.01 (near-uniform) just to keep gradients flowing —
+a workaround for one-hot ensembles, not a fix.
+
+The user's directive: keep the philosophical commitment to
+randomization-over-metadynamics. Scale ETKDG up by orders of magnitude,
+exploiting the fact that nvmolkit's GPU embed is ~100× cheaper than CREST per
+conformer. Even if we have to call nvmolkit ETKDG repeatedly with different
+seeds, this is an acceptable trade-off.
+
+---
+
+## nvmolkit ETKDG semantics — experimental findings
+
+Before scaling N to thousands, three properties of nvmolkit's
+`embedMolecules.EmbedMolecules` were checked on a 56-heavy-atom PAMPA cyclic
+peptide. The script ran each path on the same SMILES with `params` from
+`get_embed_params_macrocycle()` and then compared the resulting conformer
+coordinate matrices.
+
+| Path | Setup | conformers returned | unique-coord rows | NN distance min / median / max (Å) |
+|------|-------|---------------------|-------------------|-------------------------------------|
+| A | single call, `confsPerMolecule=200`, `randomSeed=0` | 200 | 200 | 27.8 / 43.0 / 53.6 |
+| B | two calls, `confsPerMolecule=100`, seeds 0 then 1000 | 200 | 200 | 31.4 / 43.7 / 55.6 |
+| C | two calls, `confsPerMolecule=100`, seeds 0 then 0 | 200 | 200 | — |
+
+Findings that constrain the design:
+
+1. **Path A is genuinely seed-independent within a single call.** A single
+   `EmbedMolecules(..., confsPerMolecule=N)` returns N geometrically distinct
+   conformers — no internal seed sharing collapses the batch onto a few
+   shapes. Single-call scaling is therefore viable as the fast path.
+2. **Chunking covers comparable diversity.** Path B's nearest-neighbour
+   distance distribution matches Path A's within noise. Calling
+   `EmbedMolecules` repeatedly with offset seeds is a safe fallback when
+   `n_seeds` exceeds whatever per-call ceiling the GPU memory imposes.
+3. **`params.randomSeed` does not provide cross-call bit-exact
+   reproducibility.** Two consecutive calls with `randomSeed=0` produced 200
+   distinct conformers, not the same 100 twice. Some internal random state
+   advances independently across calls. Tests that depend on coordinate
+   identity will fail intermittently; the chunk-equivalence test in Phase 4
+   must compare aggregate stats (sorted-energy distributions, basin counts)
+   instead.
+
+Implication for the implementation: use Path A as the default fast path; only
+fall back to chunking when `n_seeds > embed_chunk_size`. Plan for stochastic
+correctness tests, not coordinate-identity tests.
+
+---
+
+## Phase 0 — branch hygiene
+
+The actual `useSmallRingTorsions` flag fix landed on `main` via PR #6 (the
+`3-cremp-dataset-comparison` branch). What remains here:
+
+- The docstring in `get_embed_params_macrocycle` ([src/confsweeper.py:75-94](../src/confsweeper.py#L75-L94))
+  still describes `useSmallRingTorsions` as enabled.
+- The matching subsection in `src/README.md` ([src/README.md:24-29](../src/README.md#L24-L29))
+  also describes the flag as enabled.
+
+Update both to state that the flag is intentionally disabled because nvmolkit
+hangs in CPU preprocessing when it is set. Single small commit.
+
+---
+
+## Phase 1 — `get_mol_PE_exhaustive` core pipeline
+
+Add a new public function in `src/confsweeper.py`. Keep `get_mol_PE_batched`
+working unchanged — it remains the right tool for ETKDG-only quick experiments
+and for torsional sampling. Possible deprecation of either pre-existing path is
+deferred until the saturation experiments in Phase 2 confirm the exhaustive
+path supersedes them.
+
+### Signature
+
+```python
+def get_mol_PE_exhaustive(
+    smi: str,
+    params,
+    hardware_opts,
+    calc,
+    n_seeds: int = 5000,
+    embed_chunk_size: int = 1000,
+    score_chunk_size: int = 500,
+    e_window_kT: float = 5.0,
+    rmsd_threshold: float = 0.1,
+    minimize: bool = False,
+    seed: int = 0,
+) -> tuple[Chem.Mol, list[int], list[float]]:
+```
+
+Returns the same `(mol, centroid_ids, energies_eV)` contract as
+`get_mol_PE_batched`, so downstream consumers swap one function call.
+
+### Pipeline stages
+
+1. **Massive embed.** Path A by default: a single `EmbedMolecules` call with
+   `confsPerMolecule=n_seeds`. When `n_seeds > embed_chunk_size`, fall back to
+   Path B: chunked calls with seeds `seed + chunk_index * embed_chunk_size`,
+   appending into a single mol via `RDKit.Chem.RWMol`. Stop early if a chunk
+   returns zero conformers (likely an embedding-incompatible molecule).
+
+2. **(Optional) MMFF94 minimization.** When `minimize=True`, run
+   `AllChem.MMFFOptimizeMolecule` on each conformer in place to push
+   random-init structures into their basin minima. Default off; flip only if
+   Phase 2 ablation shows it tightens basin assignment.
+
+3. **Batched MACE scoring.** Score the full pool by calling
+   `_mace_batch_energies` in chunks of `score_chunk_size`, concatenating
+   results. Existing `_mace_batch_energies` keeps its silent fallback to
+   per-conformer ASE for non-MACE calculators.
+
+4. **Energy filter.** Drop conformers with
+   `(E - E_min) > e_window_kT * kT`. Critical for keeping geometric dedup
+   tractable: at `e_window_kT=5` (≈130 meV), survivors are typically a few
+   percent of the pool, so a 10 k-seed run drops to a few hundred before
+   clustering.
+
+5. **Energy-ranked geometric dedup** (new primitive — see below). Returns one
+   centroid per geometric basin, with the lowest-energy member chosen as
+   representative.
+
+6. **Output.** Remove non-centroid conformers from the mol, return
+   `(mol, centroid_ids, [E[c] for c in centroid_ids])`.
+
+### Energy-ranked dedup primitive
+
+Different from Butina: Butina picks dense cluster centres first; we want
+lowest-energy first so a basin's representative is its energy minimum.
+
+```python
+def _energy_ranked_dedup(
+    coords: torch.Tensor,        # [N, A, 3]
+    energies: np.ndarray,        # [N] in eV
+    rmsd_threshold: float,       # normalised L1 units, matches existing 0.1 cutoff
+) -> list[int]:
+    # Sort by energy ascending, iterate, pick lowest-energy unassigned,
+    # exclude all conformers within rmsd_threshold (normalised L1 = sum |Δ| / 3·A).
+```
+
+Implementation notes:
+- Same normalised L1 distance metric as `get_mol_PE_batched` so cutoffs are
+  comparable across both functions.
+- O(N²) worst case, but on the post-filter pool (~hundreds), so fast.
+- GPU-accelerate per-iteration distance via `torch.cdist(p=1.0)` keeping
+  `coords` on CUDA.
+- Start as private `_energy_ranked_dedup` in `confsweeper.py`. Promote to
+  `utils.py` only if a second caller appears.
+
+### Failure modes
+
+- **Zero conformers embedded** — return `(mol, [], [])` with no scoring.
+- **All conformers excluded by energy filter** — keep the lowest-energy
+  conformer unconditionally so callers always get at least one centroid.
+- **Single conformer** — skip dedup, return that conformer.
+- **GPU OOM during scoring** — surface a clear error message asking for a
+  lower `score_chunk_size`. No silent fallback for this case.
+
+### Reproducibility
+
+- `seed` parameter offsets per-chunk ETKDG seed.
+- MACE forward pass is deterministic given fixed dtype.
+- Energy-ranked dedup is deterministic given a stable sort
+  (`np.argsort(kind='stable')`).
+- Per the semantics experiment, this guarantees **statistical** reproducibility
+  (same sorted-energy distribution and basin count across runs), not
+  coordinate-bit-exact reproducibility.
+
+---
+
+## Phase 2 — saturation experiments
+
+Goal: pick `n_seeds` for the production default by finding where the
+saturation curves flatten.
+
+### Representative peptide selection
+
+Five peptides spanning the macrocycle size range:
+- 2 from CREMP (so we have CREST ground truth for `max_bw` and basin counts)
+- 3 from PAMPA, one each in small (~50 heavy atoms), medium (~70), large
+  (~100+) buckets
+
+### Sweep design
+
+For each peptide, run `n_seeds ∈ {100, 500, 1k, 5k, 10k, 50k}` and report:
+- `max_bw`, `eff_n`, `entropy` (post-dedup)
+- `n_within_kT`, `n_within_3kT`
+- `n_basins` (centroids surviving dedup)
+- wall-clock per stage (embed, MMFF if on, MACE, dedup)
+- GPU memory peak
+
+Plot saturation curves; pick `n_seeds` where each curve is within ~5 % of the
+largest tested value. CREMP cross-check: for the two CREMP peptides, our
+`(max_bw, n_basins)` distributions should land within 2× CREMP's median 25 %.
+If not even at 50 k seeds, the bottleneck is ETKDG itself (basin volume in
+random-init space is too uneven for randomization alone) and the
+exhaustive-randomization premise needs revisiting.
+
+### Ablation: `minimize=True`
+
+After picking N, repeat the largest-N run with `minimize=True` on the same 5
+peptides. Compare basin count and `n_within_3kT`. If MMFF tightens basin
+assignment without losing diversity, flip the default; otherwise leave off.
+
+### Script location
+
+`scripts/saturation_etkdg.py` — kept out of `data/` (gitignored) and out of
+`src/` (library code). New `scripts/` directory if needed.
+
+---
+
+## Phase 3 — documentation
+
+1. **`src/README.md`** — add a "Exhaustive randomized ETKDG" subsection under
+   Pipeline functions, documenting `get_mol_PE_exhaustive`'s contract, when
+   to use it (cyclic peptides without a CREMP ensemble), the trade-off vs.
+   `get_mol_PE_batched`, and the saturation-derived default N.
+2. **Module docstring** in `src/confsweeper.py` — extend the top-level
+   docstring to mention the three pipelines.
+3. **Function docstring** for `get_mol_PE_exhaustive` — full Params/Returns
+   block per CLAUDE.md plus a "When to use" note distinguishing it from
+   `get_mol_PE_batched`.
+
+---
+
+## Phase 4 — tests
+
+`tests/test_exhaustive_etkdg.py`:
+
+- `test_exhaustive_returns_centroids_and_energies` — small SMILES (4-residue
+  cyclic peptide), `n_seeds=200`, asserts non-empty outputs and
+  `len(centroids) == len(energies)`.
+- `test_energy_ranked_dedup_picks_lowest_energy` — synthetic `coords` and
+  `energies` where the lowest-energy conformer is geometrically near a
+  higher-energy one; assert lowest-energy survives.
+- `test_energy_filter_drops_high_energy` — synthetic energies covering > 5 kT
+  spread; assert filtered subset matches expectation.
+- `test_chunked_embed_aggregate_equivalent` — fixed `seed`, run with
+  `embed_chunk_size=200` and `embed_chunk_size=1000`; assert sorted-energy
+  distributions match within float32 tolerance and basin count matches
+  within ±5 %. **Not coordinate-identity** because of the Path C semantics
+  finding above.
+- `test_zero_conformers_safe` — SMILES that nvmolkit cannot embed; assert
+  `(mol, [], [])` not a crash.
+- `test_single_conformer_skips_dedup` — `n_seeds=1`; assert one centroid
+  returned.
+
+Run via `pixi run pytest tests/test_exhaustive_etkdg.py -v`.
+
+---
+
+## Phase 5 — downstream integration (separate follow-up PR)
+
+Lives in `peptide_electrostatics`, not this branch:
+1. Update `finetune_generate_conformers.py` to call `get_mol_PE_exhaustive`.
+2. Add `--n_seeds` and (optional) `--minimize` CLI args.
+3. Regenerate `data/fine_tune/pampa_conformers.pkl` (Falcon Slurm).
+4. Re-run Stage 1b + Stage 2 fine-tuning.
+5. Compare `val/mae` and learned `α` against the previous one-hot run.
+   Expectation: α drifts toward 1, MAE drops noticeably.
+
+---
+
+## Suggested commit ordering on this branch
+
+1. `Add docs/exhaustive_etkdg_plan.md and clean up useSmallRingTorsions docstrings`
+   (Phase 0 + this design doc).
+2. `Add _energy_ranked_dedup helper` (primitive + unit tests).
+3. `Add get_mol_PE_exhaustive pipeline` (embed → score → filter → dedup
+   wiring + integration tests).
+4. `Add scripts/saturation_etkdg.py and document chosen n_seeds default`
+   (Phase 2 + the chosen N propagated into the function default).
+5. `Update src/README.md with exhaustive ETKDG section`.
+
+Phases 1 and 2 land together in one PR because the saturation results
+justify the chosen default `n_seeds`. Reviewers see the data alongside the
+choice.
+
+---
+
+## Open questions
+
+- **GPU OOM ceiling for nvmolkit single-call embed** — sets the upper bound
+  on `embed_chunk_size`. Plan: start at 1000, profile during Phase 2.
+- **Does ETKDG's internal cleanup land conformers in basin minima**, or is
+  explicit MMFF / MACE local minimization required for geometric dedup to be
+  meaningful? Phase 2 ablation answers this.
+- **Does PAMPA val/MAE actually drop with rich ensembles?** Ultimate test for
+  the whole effort. Answered in Phase 5 by re-fitting `FinetuneJanossyWrapper`
+  and checking whether learned α moves toward 1 (currently lives at 0.01) and
+  whether MAE drops.

--- a/docs/exhaustive_etkdg_plan.md
+++ b/docs/exhaustive_etkdg_plan.md
@@ -77,10 +77,27 @@ Findings that constrain the design:
    identity will fail intermittently; the chunk-equivalence test in Phase 4
    must compare aggregate stats (sorted-energy distributions, basin counts)
    instead.
+4. **Repeated `EmbedMolecules` calls append rather than replace.** A second
+   call to `embed.EmbedMolecules` on the same RDKit `Mol` adds new conformers
+   to the existing set rather than overwriting them — verified empirically:
+   `EmbedMolecules(mol, confsPerMolecule=10)` followed by
+   `EmbedMolecules(mol, confsPerMolecule=10)` leaves the mol with 20
+   conformers, not 10. The chunked-embed loop in
+   `get_mol_PE_exhaustive` depends on this; if nvmolkit ever changes to
+   replace-on-call (matching `AllChem.EmbedMultipleConfs`'s default), the loop
+   collapses to producing only the last chunk's conformers. The
+   `test_exhaustive_chunked_path_accumulates_full_pool` test guards against
+   this regression. Discovered while writing the test: an initial CPU mock
+   used `EmbedMultipleConfs(..., clearConfs=True)` (the default), produced
+   only the last chunk's conformers, and triggered a clear assertion
+   failure. The mock now passes `clearConfs=False` to match nvmolkit.
 
 Implication for the implementation: use Path A as the default fast path; only
 fall back to chunking when `n_seeds > embed_chunk_size`. Plan for stochastic
-correctness tests, not coordinate-identity tests.
+correctness tests, not coordinate-identity tests. The chunked-loop's
+correctness silently depends on nvmolkit's append semantics — flag this in
+the eventual PR description so reviewers know what the regression test is
+actually catching.
 
 ---
 
@@ -314,14 +331,485 @@ choice.
 
 ---
 
+## Phase 2 results — what the saturation experiments actually found
+
+The Phase 2 plan was a sweep of `n_seeds ∈ {100, 500, 1k, 5k, 10k, 50k}` on
+five representative peptides, plus ablations on parameter mode, dihedral
+jitter, and MMFF minimization. The actual sweep ran the same grid (sans
+50k) plus three ablations:
+
+1. **Baseline grid** — `etkdgv3_macrocycle` ETKDG, no jitter, no minimize,
+   `e_window_kT=5.0`, `rmsd_threshold=0.1`. Five peptides × four seed
+   counts = 20 runs.
+2. **Mode comparison** — same grid, but with `etkdg_original` (RDKit's 2015
+   ETKDG, no macrocycle torsion knowledge) to test whether ETKDGv3's
+   torsion bias suppresses basin diversity. Five peptides × four seed
+   counts = 20 runs.
+3. **Dihedral jitter ablation** — `n=5000` only, with `dihedral_jitter_deg=15°`
+   applied per rotatable bond after embedding, on both modes. Five
+   peptides × two modes × one n_seeds = 10 runs.
+4. **MMFF minimization at n=10k** — `etkdgv3_macrocycle`,
+   `--minimize_at_largest`. Adds five `minimize=True` runs at n=10k plus
+   five `minimize=False` n=10k controls.
+
+Results live in `data/processed/saturation/saturation_etkdg.csv` (~60+
+rows) and the runtime log in `scripts/saturation_etkdg.log`. Total compute
+spent: ~3 hours of GPU time across the whole grid.
+
+### Peptide selection
+
+Five peptides spanning the macrocycle size range, two with CREST ground
+truth from CREMP and three from CycPeptMPDB PAMPA:
+
+| label | source | n_heavy | ground-truth `max_bw` | rationale |
+|---|---|---|---|---|
+| `cremp_typical:t.I.G.N` | CREMP | 27 | **0.246** | near median CREMP `poplowestpct` (~25 %) — typical rich ensemble |
+| `cremp_sharp:S.S.N.MeW.MeA.MeN` | CREMP | 50 | **0.535** | 90th-percentile `poplowestpct` — naturally sharper landscape |
+| `pampa_small` | PAMPA | 51 | — | small PAMPA bucket (≤55 heavy) |
+| `pampa_medium` | PAMPA | 70 | — | medium PAMPA bucket (60–75 heavy) |
+| `pampa_large` | PAMPA | 103 | — | large PAMPA bucket (≥95 heavy) |
+
+CREMP ground truth is `poplowestpct/100` from the validation subset
+summary CSV. Selection logic is in `select_cremp_peptides` and
+`select_pampa_peptides` of `scripts/saturation_etkdg.py`.
+
+### Headline finding: max_bw oscillates, never monotonically saturates
+
+Across every (peptide, mode, jitter) combination, the per-row `max_bw` did
+not smoothly decrease with `n_seeds`. It oscillated between ~0.4 and 1.0
+because each newly-discovered low-energy conformer reset the Boltzmann-weight
+reference: the new minimum becomes `E_min`, the previous (higher-energy)
+basin members fall outside the 5 kT energy filter, and the dedup output
+collapses back toward one-hot. The **right summary metric is
+`min(max_bw)` across the full sweep**, not the value at any single
+`n_seeds`. The saturation curves are bursty rather than monotonic, which
+matters for downstream interpretation: a single `n_seeds=N` run is not a
+reliable estimate of what the pipeline *can* find.
+
+Concrete example, baseline `etkdgv3_macrocycle` on `cremp_typical` (CREMP
+ground truth `max_bw=0.246`):
+
+| n_seeds | n_basins | max_bw |
+|---|---|---|
+| 100 | 2 | 0.907 |
+| 500 | 5 | 0.874 |
+| 1 000 | **1** | **1.000** |
+| 5 000 | 9 | **0.222** |
+| 10 000 | 1 | 1.000 |
+
+n=5000 hit the CREMP ground truth almost exactly (0.222 vs 0.246) — but
+both n=1000 and n=10000 collapsed to one-hot on the same peptide. ETKDG
+finds a new lowest-energy conformer at the larger N, which pushes the
+formerly-contributing higher-energy conformers outside the 5 kT window.
+This isn't a bug in the pipeline; it is the pipeline working correctly on
+a stochastic sampler.
+
+### Baseline grid — `etkdgv3_macrocycle`, no jitter, no minimize
+
+Best `min(max_bw)` per peptide across `n_seeds ∈ {100, 500, 1k, 5k}`:
+
+| peptide | best `max_bw` | at n_seeds | n_basins | n_within_3kT | ground truth |
+|---|---|---|---|---|---|
+| `cremp_typical` | **0.222** | 5 000 | 9 | 7 | 0.246 ✓ |
+| `cremp_sharp` | 0.821 | 500 | 2 | 2 | 0.535 ✗ |
+| `pampa_small` | 0.971 | 1 000 | 2 | 1 | — |
+| `pampa_medium` | **0.415** | 500 | 7 | 5 | — |
+| `pampa_large` | 1.000 | (any) | 1 | 1 | — |
+
+Two of five peptides responded to scaling: `cremp_typical` saturated
+correctly to CREMP, and `pampa_medium` produced a real CREMP-like
+distribution at one lucky draw (n=500). Three peptides stayed essentially
+one-hot at every grid point: `cremp_sharp` got modest BW spread but
+nowhere near its CREMP ground truth of 0.535; `pampa_small` and
+`pampa_large` never broke through.
+
+This split — "responsive" vs "stuck" peptides — drove the rest of the
+investigation. Pure scaling is necessary but not sufficient.
+
+### Mode comparison — does dropping the macrocycle prior help?
+
+Hypothesis: ETKDGv3's macrocycle torsion knowledge biases initial
+coordinate distributions toward known-low-energy regions, so we keep
+re-finding the same basin. Removing the bias (RDKit's 2015 `ETKDG()` with
+no macrocycle terms) might let randomness explore more freely.
+
+`etkdgv3_macrocycle` vs `etkdg_original`, best `min(max_bw)` across the
+same 4-point grid:
+
+| peptide | etkdgv3 best | etkdg_orig best |
+|---|---|---|
+| `cremp_typical` | **0.222** ✓ | 0.671 |
+| `cremp_sharp` | **0.821** | 0.992 |
+| `pampa_small` | 0.971 | **0.928** |
+| `pampa_medium` | **0.415** | 0.939 |
+| `pampa_large` | 1.000 | **0.966** |
+
+**Hypothesis disconfirmed.** ETKDGv3 wins on three of five peptides, and
+substantially on `cremp_typical` (0.222 vs 0.671) and `pampa_medium`
+(0.415 vs 0.939). Original ETKDG wins only on `pampa_small` and
+`pampa_large`, both marginally. The macrocycle prior is *helping*, not
+hurting — it concentrates ETKDG's random embeds in the geometrically
+plausible region of conformation space, which raises the probability that
+any given low-energy basin lies inside the random-init's reach.
+
+This rules out "v3 too biased" as an explanation for the stuck peptides.
+
+### Dihedral jitter ablation — does geometric noise push new basins?
+
+Hypothesis: a small uniform random rotation on each rotatable bond after
+embedding could push a few conformers across nearby basin boundaries
+before MACE rescoring catches them. Implemented as
+`_jitter_rotatable_dihedrals` (RDKit standard rotatable-bond SMARTS, with
+methyl-degenerate rotations filtered, applied uniformly in
+[-jitter, +jitter]°). On cyclic peptides this only perturbs side-chain
+rotamers since backbone bonds are in-ring.
+
+Tested at `dihedral_jitter_deg=15°`, `n_seeds=5000`, on both modes. Best
+no-jitter baseline vs jitter=15° at n=5000:
+
+| peptide | etkdgv3 baseline | etkdgv3 + j15 | etkdg_orig baseline | etkdg_orig + j15 |
+|---|---|---|---|---|
+| `cremp_typical` | 9 / 0.222 | 5 / 0.927 | 3 / 0.869 | 2 / 0.988 |
+| `cremp_sharp` | 1 / 1.000 | 1 / 1.000 | 2 / 0.992 | 1 / 1.000 |
+| `pampa_small` | 1 / 1.000 | 1 / 1.000 | 1 / 1.000 | 1 / 1.000 |
+| `pampa_medium` | 2 / 0.981 | 1 / 1.000 | 1 / 1.000 | 1 / 1.000 |
+| `pampa_large` | 1 / 1.000 | 2 / 0.990 | 1 / 1.000 | 1 / 1.000 |
+
+**Hypothesis disconfirmed.** Across all 10 (peptide × mode) combinations,
+jitter=15° never improved on the no-jitter best. It bumped basin counts
+on `cremp_typical` (1 → 5) and `pampa_large` (1 → 2) but did not lower
+`max_bw` in either case — the new "basins" sat too high above the
+minimum to contribute Boltzmann weight. Geometric noise without an energy
+gradient just produces extra high-energy conformers that the 5 kT filter
+discards. To make jitter useful you would need either (a) much larger
+amplitude that crosses rotamer barriers (and then re-minimize) or (b)
+backbone-targeted jitter — neither is safe for cyclic peptides without
+breaking ring closure.
+
+### Energy-backend check: MACE-OFF23 vs xtb GFN2
+
+Question: are the one-hot Boltzmann distributions a MACE-OFF23 artifact?
+CREST uses xtb GFN2 internally, so testing whether xtb produces richer
+ensembles on the *same* conformer pool would tell us whether the energy
+model itself is the cause.
+
+Implemented as `scripts/mace_vs_xtb.py`: embed N=1000 conformers of
+`pampa_large` (the most extreme stuck peptide), MACE-score the full pool
+on GPU (single batched pass), xtb GFN2 single-point on CPU in 8 parallel
+workers, compare BW vectors and energy correlations.
+
+| metric | MACE-OFF23 | xtb GFN2 |
+|---|---|---|
+| `max_bw` | 0.860 | **0.9997** |
+| `eff_n` | 1.32 | 1.00 |
+| `entropy` | 0.413 | 0.003 |
+| `n_within_kT` | 1 | 1 |
+| `n_within_3kT` | 2 | 1 |
+| `e_range` (eV) | 24.2 | 21.3 |
+
+Cross-backend correlation on the same 1 000 conformers:
+- **Pearson r = +0.991** (energies, mean-shifted)
+- **Spearman r = +0.983** (rank order)
+- Top-BW conformer agrees: both backends pick the same conformer (idx=121)
+  as the dominant one.
+
+**MACE is exonerated.** Two completely different physics — a graph neural
+network trained on QM data vs the semi-empirical tight-binding method
+that CREST uses internally — agree to within sampling noise on which
+conformer is the energy minimum and on the rank order of the rest. xtb
+is actually *more* one-hot than MACE on this pool. The bottleneck is not
+the energy model; it is the conformer pool itself. CREST gets rich
+ensembles because it samples *different conformer basins*, not because
+xtb scores them differently from MACE.
+
+This validates keeping MACE-OFF23 as the production scorer (the ~10×
+speedup vs xtb is free on equal-quality energies) and shifts the entire
+investigation back to sampling.
+
+Per-conformer CSV is at
+`data/processed/saturation/mace_vs_xtb_pampa_large.csv` for any
+follow-up scatter plots.
+
+### MMFF minimization is the lever
+
+The breakthrough finding. With everything else held fixed
+(`etkdgv3_macrocycle`, no jitter, MACE scoring, `e_window_kT=5.0`,
+`rmsd_threshold=0.1`), turning on MMFF94 post-embed minimization
+transformed the stuck cases.
+
+`cremp_typical` n=10000 baseline vs minimize=True (CPU MMFF, the first
+attempt):
+
+| | n_basins | max_bw | n_within_3kT |
+|---|---|---|---|
+| no-minimize | 1 | 1.000 | 1 |
+| **+ minimize=True (CPU MMFF)** | **75** | **0.071** | **38** |
+
+`max_bw=0.071` is *lower* than CREMP's ground truth of 0.246 — the
+ensemble is now more uniformly distributed across many basins than CREST
+itself produced. 75 basins from the same input pool is ~75× the basin
+count of the no-minimize run.
+
+Why it works: ETKDG produces conformers near basin floors but not at
+them, so the energy filter and dedup see slight geometric variations as
+separate minima. MMFF94 pulls each conformer to its actual local
+minimum. Then the energy-ranked dedup sees true basins, not noisy points
+near them — duplicates collapse correctly, and what survives are real
+basin energies rather than accidental low-energy structures within
+basins.
+
+This is the missing ingredient. Without minimization, exhaustive ETKDG
+finds basin *neighbourhoods*, not basin *minima*. With minimization,
+each conformer is decomposed into "which basin does it belong to?" and
+"what is that basin's energy?", and the dedup-and-Boltzmann-weight
+pipeline produces a proper canonical ensemble.
+
+### nvmolkit GPU MMFF integration
+
+CPU MMFF on `cremp_typical` n=10000 (27 heavy atoms) took 862 s — about
+86 ms per conformer for the smallest peptide. Scaling that to `pampa_large`
+(103 heavy atoms, 222 atoms with explicit Hs) is multi-hour per peptide.
+Not viable for production.
+
+`nvmolkit.mmffOptimization.MMFFOptimizeMoleculesConfs` provides a
+GPU-batched CUDA implementation. Quick-correctness test on 50 ETKDG
+conformers per peptide:
+
+| peptide | n_atoms | CPU MMFF | GPU MMFF | speedup | Pearson r (energies) | RMS coord delta median (Å) |
+|---|---|---|---|---|---|---|
+| cremp_typical | 34 | 0.80 s | 0.03 s | **23.6×** | 0.940 | 0.012 |
+| pampa_large | 222 | 35.7 s | 0.70 s | **50.6×** | 0.955 | 0.002 |
+
+The two backends are not bit-exact. Pearson r ≈ 0.95 between final
+energies, with std ~3-5 kcal/mol per-conformer. Median per-conformer RMS
+coordinate delta is ~0.01 Å (most conformers identical), but the tails
+diverge — different BFGS gradient details push the optimizer into
+neighbouring basins on a few percent of cases. Both are valid descents to
+local minima; just non-identical local minima. For exhaustive sampling
+the disagreement is acceptable: we care about basin coverage in
+aggregate, not per-conformer reproducibility.
+
+The integration:
+- New `mmff_backend: str = "gpu"` parameter on `get_mol_PE_exhaustive`.
+- `'gpu'` calls `MMFFOptimizeMoleculesConfs` once on the full pool;
+  `'cpu'` falls back to the original RDKit serial loop.
+- Order-dependent import: `nvmolkit.mmffOptimization` requires
+  `nvmolkit.embedMolecules` to be loaded first to register C++ global
+  state. The pipeline already imports `embed.EmbedMolecules` before
+  reaching the minimization step, so this is automatic in normal use.
+
+End-to-end speedup at n=10k on `cremp_typical`: 862 s → 291 s (3.0×).
+Smaller than the per-conformer 23.6× because at this scale the
+embed and MACE stages also dominate; MMFF is no longer the long pole.
+For `pampa_large` and similar large peptides where CPU MMFF would
+otherwise take hours, the GPU backend is the difference between viable
+and not.
+
+### Implications for the production default
+
+The data argues for these `get_mol_PE_exhaustive` defaults:
+
+- `n_seeds=10000` — saturated for small peptides, partial for large.
+  Bigger N still helps but gets stochastic; **`minimize=True` matters
+  more than scaling N further**.
+- `minimize=True` — the actual lever. Without it, even n=10k stays
+  one-hot on most peptides.
+- `mmff_backend='gpu'` — required to make minimize=True viable on the
+  large peptides that dominate PAMPA.
+- `params_mode='etkdgv3_macrocycle'` — the macrocycle prior helps, not
+  hurts. Keep it.
+- `dihedral_jitter_deg=0.0` — the rotatable-bond jitter machinery is
+  built but not on by default; no measurable benefit at jitter=15°.
+  Keep the code in case future work wants larger jitter or
+  rotamer-aware variants, but document that it's experimental.
+
+### Final n=10k saturation results — minimize splits the dataset by size
+
+The full n=10k sweep across all five peptides, no-minimize vs minimize=True
+(GPU MMFF), `etkdgv3_macrocycle`, no jitter:
+
+| peptide | n_heavy | no-minimize | minimize=True | ground truth |
+|---|---|---|---|---|
+| `cremp_typical` | 27 | 1 / 1.000 | **54 / 0.318** ✓ | 0.246 |
+| `cremp_sharp` | 50 | 1 / 1.000 | **11 / 0.380** ✓ | 0.535 |
+| `pampa_small` | 51 | 3 / 0.968 | **4 / 0.591** ✓ | — |
+| `pampa_medium` | 70 | 3 / 0.923 | 2 / 0.966 ✗ | — |
+| `pampa_large` | 103 | 3 / 0.497 | 3 / 0.930 ✗ | — |
+
+(Cells are `n_basins / max_bw`. ✓ = minimize improved; ✗ = minimize regressed.)
+
+**The split is sharp at ~70 heavy atoms.** Below that threshold,
+minimize=True is unambiguously the lever — `cremp_typical` recovered to
+CREMP-comparable BW (max_bw 0.318 vs ground truth 0.246), `cremp_sharp`
+to *better* than CREMP (0.380 vs 0.535), and `pampa_small` from one-hot
+(0.968) to a real ensemble (0.591). Above the threshold,
+minimize=True regresses: `pampa_medium` got worse (0.966 vs 0.923 without
+minimize) and `pampa_large` got substantially worse (0.930 vs 0.497).
+
+A second observation worth recording: `pampa_large` *did* finally move off
+one-hot at n=10k without minimize (max_bw=0.497, 3 basins) — the
+bursty-saturation pattern paying off at the largest scale we tested. The
+baseline grid (n ≤ 5000) had it stuck at 1.000 across every grid point.
+Pure scaling does eventually help on the largest peptide, but only at the
+top of the seed range.
+
+### Confound: input pool is not held fixed across minimize/no-minimize
+
+Before drawing conclusions about the large-peptide regression: the
+no-minimize and minimize runs use **different nvmolkit ETKDG seeds**
+because they ran as separate invocations of the saturation script.
+nvmolkit ETKDG is not bit-exact reproducible across calls (per the
+"nvmolkit ETKDG semantics" findings above), so the two runs are
+comparing not just "same pool, different processing" but "different
+pools, different processing". The pampa_large no-minimize run that
+found 3 basins / max_bw=0.497 may have drawn a particularly rich pool.
+
+Two competing hypotheses for the large-peptide regression need a
+controlled experiment to distinguish:
+
+1. **Sampling-luck hypothesis** — the no-minimize run on pampa_medium /
+   pampa_large happened to find an unusually diverse ETKDG pool, while
+   the minimize run found a poorer pool. The MMFF basin-collapse effect
+   on the poorer pool could not recover the diversity that the
+   un-minimized rich pool retained. Implication: minimize=True remains
+   the right default, just with the same bursty-saturation noise we
+   already accepted for n_seeds.
+2. **Mechanism hypothesis** — for large peptides ETKDG produces enough
+   geometric noise *within* a single basin that the 5 kT filter and
+   dedup happen to keep ~3 of those near-duplicates as "different"
+   conformers, providing fake diversity. MMFF cleans them up to a single
+   basin minimum, the dominant minimum's BW concentrates, and max_bw
+   rises. Implication: minimize=True is actively wrong for large
+   peptides; production needs a size-aware default.
+
+The next-priority controlled experiment, planned for `scripts/minimize_ablation.py`:
+embed `pampa_large` and `pampa_medium` once each at n=10k, deepcopy the
+mol, run pipeline A (MACE → filter → dedup → BW) and pipeline B
+(MMFF → MACE → filter → dedup → BW) on the *same* starting pool, report
+side-by-side. If pipeline B still regresses on the same input as
+pipeline A, the mechanism hypothesis stands. If pipeline B improves or
+matches, hypothesis 1 explains the saturation result.
+
+### Implications for the production default — pending confound resolution
+
+Until the controlled experiment lands, the recommended defaults from
+the previous subsection ("Implications for the production default") are
+provisional. Concretely:
+
+- **For peptides ≤ ~51 heavy atoms** (which covers cremp_typical, cremp_sharp,
+  pampa_small): minimize=True with GPU MMFF is the correct default. The
+  effect is reproducibly large and points the right direction.
+- **For peptides ≥ ~70 heavy atoms** (which covers pampa_medium and
+  pampa_large, and most of the PAMPA dataset above the median): the
+  minimize=True regression needs to be explained before we ship it as
+  the default. A size-conditional default (e.g., `minimize=True` only
+  when `n_heavy < 60`) is the obvious fallback if the mechanism
+  hypothesis holds, but we shouldn't commit until the controlled
+  experiment confirms the mechanism rather than sampling luck.
+
+### Controlled minimize ablation — sampling-luck hypothesis confirmed
+
+The controlled experiment is `scripts/minimize_ablation.py`. It embeds
+once per peptide at n=10k via nvmolkit ETKDG, deepcopies the mol so the
+two pipelines start from identical geometries, then runs A (MACE → filter
+→ dedup → BW) and B (GPU MMFF → MACE → filter → dedup → BW) on the same
+pool. Anything pipeline B gains over pipeline A is therefore attributable
+to the minimization step alone.
+
+Run on the two regression peptides (`pampa_large` and `pampa_medium`):
+
+| peptide | pipeline | n_basins | max_bw |
+|---|---|---|---|
+| `pampa_large` (103 heavy) | A: no minimize | 1 | 1.000 |
+| | B: minimize=True | 2 | 0.981 |
+| `pampa_medium` (70 heavy) | A: no minimize | 2 | 0.990 |
+| | B: minimize=True | **2** | **0.648** |
+
+Compare against the saturation-sweep numbers (different ETKDG pools per
+pipeline):
+
+| peptide | sweep no-min | sweep min | ablation no-min | ablation min |
+|---|---|---|---|---|
+| `pampa_large` | 0.497 (3 basins) | 0.930 (3 basins) | **1.000** (1) | **0.981** (2) |
+| `pampa_medium` | 0.923 (3 basins) | 0.966 (2 basins) | **0.990** (2) | **0.648** (2) |
+
+**Hypothesis 1 (sampling luck) wins decisively on both peptides.**
+
+For `pampa_medium` the ordering reverses entirely — on a controlled pool
+minimize=True actually drops max_bw from 0.990 to 0.648, a meaningful
+recovery toward CREMP-like ensembles. The saturation-sweep "regression"
+was an artifact of comparing two unrelated ETKDG draws.
+
+For `pampa_large`, both pipelines on the controlled pool produce
+essentially one-hot results (1.000 and 0.981). Minimize=True doesn't
+help much here, but it doesn't hurt — and the sweep's "lucky" no-min
+result of 0.497 was a statistical outlier rather than a representative
+behaviour. ETKDG simply isn't generating enough basin diversity at n=10k
+on a 103-heavy-atom macrocycle, with or without MMFF.
+
+Per-conformer MACE-energy Spearman correlation between pre-MMFF and
+post-MMFF (same conformer indices, different geometries after
+optimization):
+- `pampa_large`: r = +0.5646
+- `pampa_medium`: r = +0.6098
+
+Both moderate. MMFF substantially reorders the conformer energy ranking
+— consistent with conformers crossing basin boundaries during
+minimization, which is the prerequisite for new basins emerging in the
+post-dedup result.
+
+### Final implications for the production default
+
+The controlled ablation closes the open question. Across all five
+representative peptides, minimize=True is either reproducibly good
+(cremp_typical, cremp_sharp, pampa_small, pampa_medium) or neutral
+(pampa_large), never reproducibly worse. The size-conditional fallback
+discussed earlier is unnecessary.
+
+**Production `get_mol_PE_exhaustive` defaults backed by the data**:
+
+- `n_seeds = 10000` — covers all peptides we tested, with the bursty
+  pattern noted in earlier sections. Larger values still help on a
+  per-run-luck basis but with diminishing returns.
+- `minimize = True`
+- `mmff_backend = 'gpu'`
+- `params_mode` semantically fixed to `etkdgv3_macrocycle` (no public
+  flag yet; the function takes `params` directly and the saturation
+  script wires up the variant)
+- `dihedral_jitter_deg = 0.0`
+- `e_window_kT = 5.0`
+- `rmsd_threshold = 0.1`
+
+`pampa_large`-style peptides remain a sampling-coverage hard case — even
+with minimize=True they can stay one-hot when the seed pool happens to
+land in one basin. The bursty-saturation pattern means a run might
+luckily find diversity at any given n_seeds; in production the
+fine-tuning consumer should expect some PAMPA molecules to come back
+near-one-hot regardless of pipeline tuning.
+
+The fine-tuning wrapper's α=0.01 init is the right hedge for that
+contingency: it lets the property head learn to ignore the dominant
+conformer when the input ensemble is one-hot. With the rest of PAMPA
+producing rich CREMP-like ensembles, α should drift toward 1 during
+training; we'll see that empirically when Phase 5 runs.
+
+---
+
 ## Open questions
 
 - **GPU OOM ceiling for nvmolkit single-call embed** — sets the upper bound
-  on `embed_chunk_size`. Plan: start at 1000, profile during Phase 2.
-- **Does ETKDG's internal cleanup land conformers in basin minima**, or is
-  explicit MMFF / MACE local minimization required for geometric dedup to be
-  meaningful? Phase 2 ablation answers this.
+  on `embed_chunk_size`. Empirically `embed_chunk_size=1000` at 222 atoms
+  per conformer (pampa_large) ran without OOM during the n=10k saturation
+  runs, so the operational ceiling is at least that on a single A100/H100.
 - **Does PAMPA val/MAE actually drop with rich ensembles?** Ultimate test for
   the whole effort. Answered in Phase 5 by re-fitting `FinetuneJanossyWrapper`
   and checking whether learned α moves toward 1 (currently lives at 0.01) and
-  whether MAE drops.
+  whether MAE drops. Should now actually be possible because GPU MMFF makes
+  the per-molecule conformer regeneration step tractable across the 7.2 k
+  PAMPA dataset.
+- **CPU vs GPU MMFF reproducibility on basin distribution.** The
+  per-conformer disagreement is well-characterised (Pearson r ≈ 0.95) but
+  the *aggregate* basin distribution agreement after dedup is not.
+  Worth a one-off run that fixes the input conformer pool and only
+  varies the MMFF backend (the current data conflates ETKDG seed
+  variation with backend variation).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,116 @@
+# scripts/
+
+Diagnostic and saturation-experiment scripts that drive `confsweeper`'s
+public pipeline functions on real data. Distinct from `src/` (library code)
+and `tests/` (correctness tests): these are research tools meant to be run
+from the command line on a GPU node, and their outputs feed design
+decisions rather than CI.
+
+## Why this directory exists
+
+`/data/` is `.gitignore`d in this repo, which is the right policy for raw
+datasets but the wrong place for analysis code we want to track. Similarly,
+`/src/` is reserved for the importable library — runnable diagnostic
+scripts that consume the library don't belong there. `scripts/` fills the
+gap.
+
+## Module contents
+
+### `saturation_etkdg.py`
+
+Sweeps `n_seeds` over a fixed set of representative cyclic peptides for
+`get_mol_PE_exhaustive` and writes per-run Boltzmann-weight statistics to a
+CSV. The Phase 2 diagnostic from `docs/exhaustive_etkdg_plan.md`: its job
+is to tell us where the saturation curves of `max_bw` and `n_within_3kT`
+flatten so we can pick a defensible production default for `n_seeds`.
+
+`--params_mode` selects the ETKDG variant. `etkdgv3_macrocycle` (default) is
+the production setting from `get_embed_params_macrocycle`. `etkdg_original`
+is RDKit's 2015 ETKDG with no macrocycle-specific torsion knowledge; it
+exists to test the hypothesis that ETKDGv3's macrocycle bias suppresses
+low-energy basin diversity in the post-MACE-rescore step.
+
+`--dihedral_jitter_deg` (default 0) applies a uniform random rotation in
+`[-jitter, +jitter]` degrees to every rotatable-bond dihedral on every
+embedded conformer before MACE scoring. Used to push side-chain rotamer
+exploration past ETKDG's torsion-knowledge bias. Macrocycle backbone
+bonds are excluded by the rotatable-bond SMARTS, so on cyclic peptides
+this jitters side chains only.
+
+All three knobs (mode, n_seeds, jitter) can write into the same output
+CSV — rows are keyed by `(peptide_id, params_mode, n_seeds, minimize,
+dihedral_jitter_deg)`.
+
+Selects 5 peptides (2 CREMP — one near median `poplowestpct`, one in the
+high tail; 3 PAMPA — small, medium, large heavy-atom buckets) so the run
+covers the full chemical-size range and gives us CREST ground truth on the
+two CREMP picks for sanity-checking. CREMP `poplowestpct/100` and
+`uniqueconfs` are passed through to the output CSV in the
+`ground_truth_*` columns.
+
+Writes results one row at a time and is resume-safe: rerunning with the
+same `--out_csv` skips `(peptide_id, n_seeds, minimize)` tuples that are
+already in the file.
+
+### Output CSV columns
+
+See the `OUTPUT_COLUMNS` constant in `saturation_etkdg.py` for the full
+list. The diagnostic columns are `n_basins`, `max_bw`, `eff_n`, `entropy`,
+`n_within_kT`, `n_within_3kT` per run, plus per-stage timings.
+`ground_truth_max_bw` and `ground_truth_n_confs` are populated only for
+CREMP rows (NaN for PAMPA).
+
+### `minimize_ablation.py`
+
+Controlled ablation: same nvmolkit ETKDG starting pool, two scoring
+pipelines side-by-side. Pipeline A is MACE → energy filter → energy-ranked
+dedup → BW. Pipeline B is GPU MMFF → MACE → same filter → same dedup → BW.
+Removes the confound from the saturation sweep, where the no-minimize and
+minimize=True runs used different ETKDG seeds and therefore different
+starting pools.
+
+Defaults to `pampa_large` (the most extreme regression case from the
+saturation results). Pass `--peptides` comma-separated to run on multiple
+peptides in one invocation. Sources SMILES + heavy-atom counts from
+`saturation_etkdg.csv` so the comparison is on the exact same molecules
+the sweep evaluated.
+
+### `mace_vs_xtb.py`
+
+Side-by-side energy benchmark on a single peptide: embeds one conformer
+pool, scores it with MACE-OFF23 (GPU, batched) and xtb GFN2 (CPU,
+parallel subprocess pool), then reports Boltzmann-weight statistics
+under each backend plus Pearson and Spearman correlations between the
+two energy vectors.
+
+The point is to rule MACE in or out as the cause of the near-one-hot
+Boltzmann distributions on cyclic peptides. If both backends produce
+similar BW vectors on the same conformer set, sampling is the bottleneck
+and the energy model is fine. If they disagree, the production pipeline's
+backend choice matters and we'd need to rescore (or replace MACE).
+
+Self-contained: takes a SMILES, runs the pool through both backends, and
+prints results. Does not write into the saturation CSV. Optional
+per-conformer CSV (`--out_csv`) preserves both energies for follow-up.
+
+## Critical parameters or constraints
+
+- The script imports from `src/confsweeper.py` directly via
+  `sys.path.insert`, so it must be run with the confsweeper pixi
+  environment active. `pixi run python scripts/saturation_etkdg.py …`.
+- nvmolkit and MACE both run on GPU 0 by default. There is no multi-GPU
+  scheduler — long runs block on a single device.
+- Default `n_seeds_grid` (`100,500,1000,5000,10000,50000`) is the grid
+  recommended by the design plan. Smaller grids are fine for quick
+  validation; the published default is meant to be replaced by whatever
+  the saturation curve actually requires.
+
+## Dependencies on other modules
+
+- Reads from `data/processed/cremp/validation_subset.csv` (in this repo,
+  but gitignored — generated upstream from CREMP raw data).
+- Reads from `peptide_electrostatics:data/fine_tune/CycPeptMPDB_PAMPA_deduped.csv`
+  (in the sibling repo).
+- Calls `confsweeper.get_mol_PE_exhaustive`,
+  `get_embed_params_macrocycle`, `get_hardware_opts`, `get_mace_calc`,
+  and the private constant `_KT_EV_298K`.

--- a/scripts/mace_vs_xtb.py
+++ b/scripts/mace_vs_xtb.py
@@ -1,0 +1,405 @@
+"""
+MACE-OFF23 vs xtb GFN2 single-point energy comparison on the same conformer pool.
+
+Purpose: rule MACE out (or in) as the cause of the near-one-hot Boltzmann weight
+distributions seen in the saturation experiments. If both backends produce
+similar BW vectors on the same conformer set, sampling is the bottleneck and
+the energy model is fine. If MACE concentrates BW while xtb spreads it (or
+vice-versa), the energy model itself is suspect and the production pipeline's
+backend choice matters.
+
+Pipeline (one peptide per invocation):
+    1. Embed n_seeds conformers via nvmolkit ETKDG (etkdgv3_macrocycle params).
+    2. Score the full pool with MACE batched on GPU (single forward pass).
+    3. Score the same pool with xtb GFN2 single-point in parallel CPU workers.
+    4. Compute BW vectors under each backend and report:
+         - max_bw, eff_n, n_within_kT, n_within_3kT (per backend)
+         - Pearson r of (E_MACE - mean) vs (E_xtb - mean)
+         - Spearman rank correlation (rank stability across backends)
+         - max disagreement: highest-BW conformer under each backend
+                             and how the other backend scores it
+    5. Optionally write a per-conformer CSV with both energies for follow-up.
+
+xtb is CPU-only and runs as multiple subprocess workers (default 8). MACE
+runs on GPU. The two stages are sequential but can coexist with a running
+GPU sweep — the script does its GPU work first (embed + MACE) and then
+hands off to CPU xtb workers.
+
+Usage (in the confsweeper pixi environment):
+
+    pixi run python scripts/mace_vs_xtb.py \\
+        --smiles "..." \\
+        --n_seeds 1000 \\
+        --xtb_workers 8 \\
+        --out_csv /tmp/mace_vs_xtb_pampa_large.csv
+"""
+
+from __future__ import annotations
+
+import csv
+import multiprocessing as mp
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import click
+import numpy as np
+
+# fmt: off
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+import nvmolkit.embedMolecules as embed  # noqa: E402  (must come after sys.path tweak)
+
+from confsweeper import (  # noqa: E402
+    _KT_EV_298K,
+    _mace_batch_energies,
+    get_embed_params_macrocycle,
+    get_hardware_opts,
+    get_mace_calc,
+)
+
+# fmt: on
+
+
+_HARTREE_TO_EV = 27.211386245988
+
+
+def _bw(energies_eV: np.ndarray) -> np.ndarray:
+    """
+    Compute normalised Boltzmann weights at 298 K from energies in eV.
+
+    Params:
+        energies_eV: ndarray [N] : per-conformer energies in eV
+    Returns:
+        ndarray [N] float64 of weights summing to 1
+    """
+    e = np.asarray(energies_eV, dtype=np.float64)
+    w = np.exp(-(e - e.min()) / _KT_EV_298K)
+    return w / w.sum()
+
+
+def _bw_summary(energies_eV: np.ndarray) -> dict:
+    """
+    Boltzmann-weight summary stats for a single energy backend.
+
+    Params:
+        energies_eV: ndarray [N] : per-conformer energies in eV
+    Returns:
+        dict with keys n, max_bw, eff_n, entropy, n_within_kT, n_within_3kT,
+            e_min_eV, e_range_eV
+    """
+    e = np.asarray(energies_eV, dtype=np.float64)
+    if e.size == 0:
+        return {"n": 0}
+    w = _bw(e)
+    de = e - e.min()
+    return {
+        "n": int(e.size),
+        "max_bw": float(w.max()),
+        "eff_n": float(1.0 / (w**2).sum()),
+        "entropy": float(-(w * np.log(w.clip(1e-45))).sum()),
+        "n_within_kT": int((de <= _KT_EV_298K).sum()),
+        "n_within_3kT": int((de <= 3 * _KT_EV_298K).sum()),
+        "e_min_eV": float(e.min()),
+        "e_range_eV": float(de.max()),
+    }
+
+
+def _write_xyz(symbols: list[str], coords: np.ndarray, path: str) -> None:
+    """
+    Write an XYZ file (n-line header + element + coords).
+
+    Params:
+        symbols: list[str] : atomic element symbols, length N
+        coords: ndarray [N, 3] float : Cartesian positions in Å
+        path: str : output file path
+    Returns:
+        None
+    """
+    n = len(symbols)
+    lines = [str(n), ""]
+    for sym, (x, y, z) in zip(symbols, coords):
+        lines.append(f"{sym:2s}  {x:14.8f}  {y:14.8f}  {z:14.8f}")
+    Path(path).write_text("\n".join(lines) + "\n")
+
+
+def _xtb_one(args: tuple[str, list[str], np.ndarray]) -> float:
+    """
+    Run xtb GFN2 single-point on one conformer and return the energy in eV.
+
+    Designed for use in a multiprocessing.Pool — accepts a single tuple arg.
+    Sets OMP_NUM_THREADS=1 in the worker environment so the pool's parallelism
+    is across conformers, not within each xtb call.
+
+    Params:
+        args: tuple : (label, symbols, coords [N, 3])
+    Returns:
+        float : MACE-comparable energy in eV (sign-aligned), NaN if xtb failed
+    """
+    label, symbols, coords = args
+    env = {**os.environ, "OMP_NUM_THREADS": "1"}
+    with tempfile.TemporaryDirectory() as td:
+        xyz = os.path.join(td, f"{label}.xyz")
+        _write_xyz(symbols, coords, xyz)
+        result = subprocess.run(
+            ["xtb", xyz, "--gfn", "2", "--sp", "--silent", "--norestart"],
+            cwd=td,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    if result.returncode != 0:
+        return float("nan")
+    for line in result.stdout.splitlines():
+        if "TOTAL ENERGY" in line:
+            # Format: "| TOTAL ENERGY              -172.0109957 Eh   |"
+            try:
+                hartree = float(line.split()[3])
+                return hartree * _HARTREE_TO_EV
+            except (IndexError, ValueError):
+                return float("nan")
+    return float("nan")
+
+
+def _embed_pool(smi: str, n_seeds: int, hardware_opts) -> tuple[list[str], np.ndarray]:
+    """
+    Embed `n_seeds` ETKDG conformers via nvmolkit using macrocycle params.
+
+    Params:
+        smi: str : input SMILES
+        n_seeds: int : number of conformer attempts
+        hardware_opts : nvmolkit hardware options
+    Returns:
+        tuple (symbols, coords) where symbols is a list of element symbols
+        (length N atoms) and coords is an ndarray [n_conformers, N, 3]
+    """
+    from rdkit import Chem
+
+    params = get_embed_params_macrocycle()
+    params.randomSeed = 0
+    mol = Chem.AddHs(Chem.MolFromSmiles(smi))
+    embed.EmbedMolecules(
+        [mol], params, confsPerMolecule=n_seeds, hardwareOptions=hardware_opts
+    )
+    n_conf = mol.GetNumConformers()
+    if n_conf == 0:
+        return [], np.zeros((0, 0, 3), dtype=np.float64)
+    symbols = [a.GetSymbol() for a in mol.GetAtoms()]
+    coords = np.stack(
+        [
+            np.asarray(mol.GetConformer(c.GetId()).GetPositions(), dtype=np.float64)
+            for c in mol.GetConformers()
+        ]
+    )
+    return symbols, coords
+
+
+def _score_mace(
+    symbols: list[str], coords: np.ndarray, calc, score_chunk_size: int
+) -> np.ndarray:
+    """
+    MACE-score every conformer in `coords` in chunks of `score_chunk_size`.
+
+    Params:
+        symbols: list[str] : per-atom element symbols
+        coords: ndarray [n_conf, n_atoms, 3] : conformer geometries
+        calc : MACECalculator from get_mace_calc()
+        score_chunk_size: int : per-batch MACE forward pass cap
+    Returns:
+        ndarray [n_conf] float : MACE energies in eV
+    """
+    import ase
+
+    n = coords.shape[0]
+    out = np.empty(n, dtype=np.float64)
+    for start in range(0, n, score_chunk_size):
+        chunk = coords[start : start + score_chunk_size]
+        ase_mols = [ase.Atoms(positions=c, symbols=symbols) for c in chunk]
+        out[start : start + len(chunk)] = _mace_batch_energies(calc, ase_mols)
+    return out
+
+
+def _score_xtb(symbols: list[str], coords: np.ndarray, n_workers: int) -> np.ndarray:
+    """
+    xtb GFN2 single-point energies for every conformer in `coords`, in parallel.
+
+    Each worker runs an independent xtb subprocess with OMP_NUM_THREADS=1.
+
+    Params:
+        symbols: list[str] : per-atom element symbols
+        coords: ndarray [n_conf, n_atoms, 3] : conformer geometries
+        n_workers: int : number of parallel xtb subprocesses
+    Returns:
+        ndarray [n_conf] float : xtb energies in eV (NaN on failure)
+    """
+    args_list = [(f"c{i}", symbols, coords[i]) for i in range(coords.shape[0])]
+    if n_workers <= 1:
+        return np.asarray([_xtb_one(a) for a in args_list], dtype=np.float64)
+    with mp.Pool(processes=n_workers) as pool:
+        return np.asarray(pool.map(_xtb_one, args_list), dtype=np.float64)
+
+
+def _print_summary(label: str, summary: dict) -> None:
+    """
+    Print a single-backend BW summary block.
+
+    Params:
+        label: str : header label (e.g. 'MACE' or 'xtb')
+        summary: dict : output of _bw_summary
+    Returns:
+        None
+    """
+    print(f"  ── {label}")
+    print(f"      n_conformers:  {summary['n']}")
+    print(f"      max_bw:        {summary['max_bw']:.4f}")
+    print(f"      eff_n:         {summary['eff_n']:.2f}")
+    print(f"      entropy:       {summary['entropy']:.4f}")
+    print(f"      n<=kT:         {summary['n_within_kT']}")
+    print(f"      n<=3kT:        {summary['n_within_3kT']}")
+    print(f"      e_min  (eV):   {summary['e_min_eV']:.4f}")
+    print(f"      e_range (eV):  {summary['e_range_eV']:.4f}")
+
+
+def _correlation_block(e_mace: np.ndarray, e_xtb: np.ndarray) -> None:
+    """
+    Print Pearson and Spearman correlations + max-BW disagreement diagnostics.
+
+    Params:
+        e_mace: ndarray [n] float : MACE energies in eV
+        e_xtb: ndarray [n] float : xtb energies in eV (may contain NaN)
+    Returns:
+        None
+    """
+    mask = ~(np.isnan(e_mace) | np.isnan(e_xtb))
+    em, ex = e_mace[mask], e_xtb[mask]
+    n = mask.sum()
+    print(f"  ── cross-backend (n={n} valid pairs)")
+    if n < 2:
+        print("      not enough valid pairs to compute correlations")
+        return
+    # Pearson on relative energies
+    pearson = float(np.corrcoef(em - em.mean(), ex - ex.mean())[0, 1])
+    # Spearman on ranks
+    rm = np.argsort(np.argsort(em))
+    rx = np.argsort(np.argsort(ex))
+    spearman = float(np.corrcoef(rm, rx)[0, 1])
+    print(f"      Pearson r (eV-shifted):  {pearson:+.4f}")
+    print(f"      Spearman r (rank):       {spearman:+.4f}")
+    # Disagreement: pick top-1 BW conformer under each backend, see what the
+    # other backend says about it.
+    bw_m, bw_x = _bw(em), _bw(ex)
+    top_m, top_x = int(np.argmax(bw_m)), int(np.argmax(bw_x))
+    if top_m == top_x:
+        print(
+            f"      top-BW conformer agrees: idx={top_m}  (BW_MACE={bw_m[top_m]:.4f}, BW_xtb={bw_x[top_x]:.4f})"
+        )
+    else:
+        print(f"      top-BW disagreement:")
+        print(
+            f"        MACE picks conformer {top_m}: BW_MACE={bw_m[top_m]:.4f}, BW_xtb={bw_x[top_m]:.4f}"
+        )
+        print(
+            f"        xtb  picks conformer {top_x}: BW_MACE={bw_m[top_x]:.4f}, BW_xtb={bw_x[top_x]:.4f}"
+        )
+
+
+@click.command()
+@click.option("--smiles", required=True, help="SMILES of the peptide to benchmark")
+@click.option(
+    "--label", default="peptide", help="Human-readable label for output headers"
+)
+@click.option("--n_seeds", default=1000, type=int)
+@click.option(
+    "--xtb_workers",
+    default=8,
+    type=int,
+    help="Number of parallel xtb subprocesses (each pinned to OMP_NUM_THREADS=1)",
+)
+@click.option(
+    "--score_chunk_size", default=500, type=int, help="MACE batched forward-pass cap"
+)
+@click.option(
+    "--out_csv",
+    default=None,
+    type=Path,
+    help="Optional per-conformer CSV with both energies",
+)
+def main(
+    smiles: str,
+    label: str,
+    n_seeds: int,
+    xtb_workers: int,
+    score_chunk_size: int,
+    out_csv: Path | None,
+) -> None:
+    """
+    Embed one peptide pool, score it under MACE and xtb, report comparison.
+
+    Params:
+        smiles: str : SMILES of the peptide
+        label: str : output label
+        n_seeds: int : number of ETKDG seeds to embed
+        xtb_workers: int : parallel xtb workers
+        score_chunk_size: int : MACE forward-pass cap
+        out_csv: Path | None : optional per-conformer CSV with both energies
+    Returns:
+        None
+    """
+    print(f"=== {label} ===  smiles={smiles[:60]}{'...' if len(smiles) > 60 else ''}")
+    print(f"n_seeds={n_seeds}  xtb_workers={xtb_workers}")
+
+    hw = get_hardware_opts()
+    t = time.perf_counter()
+    symbols, coords = _embed_pool(smiles, n_seeds, hw)
+    t_embed = time.perf_counter() - t
+    n_conf, n_atoms = coords.shape[0], coords.shape[1]
+    print(
+        f"\n[1/3] embed:  {n_conf}/{n_seeds} conformers, {n_atoms} atoms,  {t_embed:.1f}s"
+    )
+    if n_conf == 0:
+        print("ABORT: no conformers embedded")
+        return
+
+    print(f"\n[2/3] MACE scoring  (batched, GPU)")
+    calc = get_mace_calc()
+    t = time.perf_counter()
+    e_mace = _score_mace(symbols, coords, calc, score_chunk_size=score_chunk_size)
+    t_mace = time.perf_counter() - t
+    print(f"      done: {t_mace:.1f}s  ({1000 * t_mace / n_conf:.1f} ms/conf)")
+
+    print(f"\n[3/3] xtb scoring  ({xtb_workers} workers, 1 thread each)")
+    t = time.perf_counter()
+    e_xtb = _score_xtb(symbols, coords, n_workers=xtb_workers)
+    t_xtb = time.perf_counter() - t
+    n_xtb_ok = int((~np.isnan(e_xtb)).sum())
+    print(
+        f"      done: {t_xtb:.1f}s ({1000 * t_xtb / n_conf:.1f} ms/conf wall, "
+        f"{1000 * t_xtb * xtb_workers / n_conf:.1f} ms/conf CPU)  "
+        f"{n_xtb_ok}/{n_conf} succeeded"
+    )
+
+    print()
+    print("===  Boltzmann-weight comparison  ===")
+    print()
+    _print_summary("MACE", _bw_summary(e_mace))
+    print()
+    valid = ~np.isnan(e_xtb)
+    if valid.sum() > 0:
+        _print_summary("xtb (GFN2)", _bw_summary(e_xtb[valid]))
+    print()
+    _correlation_block(e_mace, e_xtb)
+
+    if out_csv is not None:
+        out_csv.parent.mkdir(parents=True, exist_ok=True)
+        with out_csv.open("w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(["conf_idx", "e_mace_eV", "e_xtb_eV"])
+            for i, (em, ex) in enumerate(zip(e_mace, e_xtb)):
+                w.writerow([i, f"{em:.6f}", f"{ex:.6f}" if not np.isnan(ex) else ""])
+        print(f"\nper-conformer CSV written to {out_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/minimize_ablation.py
+++ b/scripts/minimize_ablation.py
@@ -1,0 +1,465 @@
+"""
+Controlled MMFF-minimization ablation: same input pool, only the minimize
+flag varies.
+
+Motivation: the n=10k saturation results showed minimize=True regressing on
+the larger PAMPA peptides (pampa_medium, pampa_large) but improving smaller
+ones. Confound: the no-minimize and minimize runs in the saturation sweep
+used different nvmolkit ETKDG seeds and therefore different starting pools,
+so we cannot attribute the regression to MMFF rather than ETKDG draw luck.
+
+This script removes the confound by embedding once and running pipeline A
+(MACE → filter → dedup → BW) and pipeline B (MMFF → MACE → filter → dedup
+→ BW) on the **same starting pool**. Side-by-side BW statistics tell us
+whether MMFF itself causes the regression on large peptides or whether the
+saturation-sweep regression was sampling luck.
+
+Pipeline:
+    1. Embed n_seeds conformers via nvmolkit ETKDG (etkdgv3_macrocycle).
+    2. Deepcopy the mol so both pipelines start from identical geometries.
+    3. Pipeline A (no minimize): MACE-score → energy filter → dedup → BW.
+    4. Pipeline B (minimize=True): GPU MMFF in place → MACE-score → energy
+       filter → dedup → BW.
+    5. Print BW summaries side-by-side, plus per-conformer correlations and
+       basin-membership comparison.
+
+Designed to run on multiple peptides in one invocation by passing
+--peptides comma-separated. Defaults to pampa_large (the most extreme
+regression case from the saturation sweep).
+
+Usage:
+
+    pixi run python scripts/minimize_ablation.py \\
+        --peptides pampa_large,pampa_medium \\
+        --n_seeds 10000 \\
+        --out_csv /home/sabari/confsweeper/data/processed/saturation/minimize_ablation.csv
+"""
+
+from __future__ import annotations
+
+import csv
+import sys
+import time
+from pathlib import Path
+
+import click
+import numpy as np
+
+# fmt: off
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+import nvmolkit.embedMolecules as embed  # noqa: E402
+
+from confsweeper import (  # noqa: E402
+    _KT_EV_298K,
+    _energy_ranked_dedup,
+    _mace_batch_energies,
+    get_embed_params_macrocycle,
+    get_hardware_opts,
+    get_mace_calc,
+)
+
+# fmt: on
+
+
+# Built-in peptide library — sourced from the saturation sweep so the
+# comparison is on the exact same molecules.
+PEPTIDE_LIBRARY: dict[str, dict] = {
+    "cremp_typical": {
+        "smiles": "OCC(N)C(=O)NC(C)C(=O)N1CCCC1C(=O)NCC(=O)N",  # placeholder; replaced from CSV at startup
+        "n_heavy_expected": 27,
+    },
+    "cremp_sharp": {
+        "smiles": None,
+        "n_heavy_expected": 50,
+    },
+    "pampa_small": {
+        "smiles": None,
+        "n_heavy_expected": 51,
+    },
+    "pampa_medium": {
+        "smiles": None,
+        "n_heavy_expected": 70,
+    },
+    "pampa_large": {
+        "smiles": None,
+        "n_heavy_expected": 103,
+    },
+}
+
+OUTPUT_COLUMNS = [
+    "peptide_id",
+    "n_heavy",
+    "n_seeds",
+    "n_pool",
+    "pipeline",
+    "n_basins",
+    "max_bw",
+    "eff_n",
+    "entropy",
+    "n_within_kT",
+    "n_within_3kT",
+    "e_min_eV",
+    "e_range_eV",
+    "time_total_s",
+]
+
+
+def _load_peptide_smiles(saturation_csv: Path) -> dict[str, dict]:
+    """
+    Look up SMILES strings for the saturation peptide library by reading the
+    saturation results CSV (which already contains them in the `smiles`
+    column, recorded per row).
+
+    Params:
+        saturation_csv: Path : saturation_etkdg.csv (output of saturation sweep)
+    Returns:
+        dict[str, dict] : peptide library keyed by peptide_id base label
+    """
+    import pandas as pd
+
+    df = pd.read_csv(saturation_csv)
+    library: dict[str, dict] = {}
+    for _, row in df.drop_duplicates("peptide_id").iterrows():
+        # Strip any "label:sequence" suffix the CREMP picks use, then keep
+        # the base label.
+        base = row["peptide_id"].split(":")[0]
+        if base not in library:
+            library[base] = {
+                "peptide_id": row["peptide_id"],
+                "smiles": row["smiles"],
+                "n_heavy": int(row["n_heavy"]),
+            }
+    return library
+
+
+def _bw_summary(energies_eV: np.ndarray) -> dict:
+    """
+    Boltzmann-weight summary stats for a single basin set.
+
+    Params:
+        energies_eV: ndarray [N] : per-basin energies in eV
+    Returns:
+        dict with keys n_basins, max_bw, eff_n, entropy, n_within_kT,
+            n_within_3kT, e_min_eV, e_range_eV
+    """
+    e = np.asarray(energies_eV, dtype=np.float64)
+    if e.size == 0:
+        return dict(
+            n_basins=0,
+            max_bw=float("nan"),
+            eff_n=float("nan"),
+            entropy=float("nan"),
+            n_within_kT=0,
+            n_within_3kT=0,
+            e_min_eV=float("nan"),
+            e_range_eV=float("nan"),
+        )
+    de = e - e.min()
+    w = np.exp(-de / _KT_EV_298K)
+    w = w / w.sum()
+    return {
+        "n_basins": int(e.size),
+        "max_bw": float(w.max()),
+        "eff_n": float(1.0 / (w**2).sum()),
+        "entropy": float(-(w * np.log(w.clip(1e-45))).sum()),
+        "n_within_kT": int((de <= _KT_EV_298K).sum()),
+        "n_within_3kT": int((de <= 3 * _KT_EV_298K).sum()),
+        "e_min_eV": float(e.min()),
+        "e_range_eV": float(de.max()),
+    }
+
+
+def _embed_pool(smi: str, n_seeds: int, hardware_opts, embed_chunk_size: int):
+    """
+    Embed `n_seeds` conformers via nvmolkit ETKDG (etkdgv3_macrocycle params).
+    Chunked when n_seeds > embed_chunk_size to bound GPU memory.
+
+    Params:
+        smi: str : SMILES
+        n_seeds: int : total seeds
+        hardware_opts : nvmolkit hardware options
+        embed_chunk_size: int : per-call cap
+    Returns:
+        rdkit.Chem.Mol with conformers attached
+    """
+    from rdkit import Chem
+
+    params = get_embed_params_macrocycle()
+    mol = Chem.AddHs(Chem.MolFromSmiles(smi))
+    if n_seeds <= embed_chunk_size:
+        params.randomSeed = 0
+        embed.EmbedMolecules(
+            [mol], params, confsPerMolecule=n_seeds, hardwareOptions=hardware_opts
+        )
+    else:
+        n_remaining = n_seeds
+        chunk_idx = 0
+        while n_remaining > 0:
+            this_chunk = min(embed_chunk_size, n_remaining)
+            params.randomSeed = chunk_idx * embed_chunk_size
+            n_before = mol.GetNumConformers()
+            embed.EmbedMolecules(
+                [mol],
+                params,
+                confsPerMolecule=this_chunk,
+                hardwareOptions=hardware_opts,
+            )
+            if mol.GetNumConformers() == n_before:
+                break
+            n_remaining -= this_chunk
+            chunk_idx += 1
+    return mol
+
+
+def _score_pool_mace(mol, calc, score_chunk_size: int) -> np.ndarray:
+    """
+    MACE-score every conformer attached to `mol` in chunks. Returns ndarray [N].
+
+    Params:
+        mol : RDKit mol with conformers
+        calc : MACE calculator
+        score_chunk_size: int : per-batch cap
+    Returns:
+        ndarray [N] float64 of energies in eV, in conformer ID order
+    """
+    import ase
+
+    conf_ids = [c.GetId() for c in mol.GetConformers()]
+    atomic_nums = [a.GetAtomicNum() for a in mol.GetAtoms()]
+    out = np.empty(len(conf_ids), dtype=np.float64)
+    for start in range(0, len(conf_ids), score_chunk_size):
+        chunk_ids = conf_ids[start : start + score_chunk_size]
+        ase_mols = [
+            ase.Atoms(
+                positions=mol.GetConformer(cid).GetPositions(), numbers=atomic_nums
+            )
+            for cid in chunk_ids
+        ]
+        out[start : start + len(chunk_ids)] = _mace_batch_energies(calc, ase_mols)
+    return out
+
+
+def _filter_and_dedup(
+    mol,
+    energies_eV: np.ndarray,
+    e_window_kT: float,
+    rmsd_threshold: float,
+) -> tuple[list[int], np.ndarray]:
+    """
+    Apply 5 kT energy filter then energy-ranked geometric dedup.
+
+    Params:
+        mol : RDKit mol with conformers (used to fetch positions for dedup)
+        energies_eV: ndarray [N] : per-conformer energies in eV
+        e_window_kT: float : energy filter window in kT_298K units
+        rmsd_threshold: float : geometric dedup exclusion radius
+    Returns:
+        tuple (kept_conf_ids, kept_energies) of basin centroids
+    """
+    import torch
+
+    conf_ids = [c.GetId() for c in mol.GetConformers()]
+    e = np.asarray(energies_eV, dtype=np.float64)
+    e_min = e.min()
+    keep = (e - e_min) <= e_window_kT * _KT_EV_298K
+    if not keep.any():
+        keep = np.zeros_like(keep)
+        keep[int(np.argmin(e))] = True
+    kept_idx = np.where(keep)[0].tolist()
+    kept_ids = [conf_ids[i] for i in kept_idx]
+    kept_e = e[kept_idx]
+    if len(kept_ids) == 1:
+        return kept_ids, kept_e
+    coords = torch.tensor(
+        np.array([mol.GetConformer(cid).GetPositions() for cid in kept_ids])
+    )
+    centroid_idx = _energy_ranked_dedup(coords, kept_e, rmsd_threshold=rmsd_threshold)
+    return [kept_ids[i] for i in centroid_idx], np.asarray(
+        [kept_e[i] for i in centroid_idx], dtype=np.float64
+    )
+
+
+def _print_summary(pipeline_label: str, summary: dict, t_total: float) -> None:
+    """
+    Print one pipeline's BW summary block.
+
+    Params:
+        pipeline_label: str : display label ('A: no-minimize' or 'B: minimize=True')
+        summary: dict : output of _bw_summary
+        t_total: float : wall-clock seconds for this pipeline
+    Returns:
+        None
+    """
+    print(f"  ── {pipeline_label}  ({t_total:.1f}s)")
+    print(f"      n_basins:      {summary['n_basins']}")
+    print(f"      max_bw:        {summary['max_bw']:.4f}")
+    print(f"      eff_n:         {summary['eff_n']:.2f}")
+    print(f"      entropy:       {summary['entropy']:.4f}")
+    print(f"      n<=kT:         {summary['n_within_kT']}")
+    print(f"      n<=3kT:        {summary['n_within_3kT']}")
+    print(f"      e_range (eV):  {summary['e_range_eV']:.4f}")
+
+
+@click.command()
+@click.option(
+    "--peptides",
+    default="pampa_large",
+    help="Comma-separated peptide labels from the saturation library "
+    "(any of cremp_typical, cremp_sharp, pampa_small, pampa_medium, pampa_large)",
+)
+@click.option(
+    "--saturation_csv",
+    default=Path(
+        "/home/sabari/confsweeper/data/processed/saturation/saturation_etkdg.csv"
+    ),
+    type=Path,
+    help="CSV used to look up SMILES + n_heavy for each peptide label",
+)
+@click.option("--n_seeds", default=10000, type=int)
+@click.option("--embed_chunk_size", default=1000, type=int)
+@click.option("--score_chunk_size", default=500, type=int)
+@click.option("--e_window_kT", default=5.0, type=float)
+@click.option("--rmsd_threshold", default=0.1, type=float)
+@click.option(
+    "--out_csv",
+    default=None,
+    type=Path,
+    help="Optional output CSV with one row per (peptide, pipeline)",
+)
+def main(
+    peptides: str,
+    saturation_csv: Path,
+    n_seeds: int,
+    embed_chunk_size: int,
+    score_chunk_size: int,
+    e_window_kt: float,
+    rmsd_threshold: float,
+    out_csv: Path | None,
+) -> None:
+    """
+    Run the controlled minimize=True vs minimize=False ablation on each
+    requested peptide, embedding once and scoring twice.
+
+    Params:
+        peptides: str : comma-separated peptide labels
+        saturation_csv: Path : source of SMILES + n_heavy lookups
+        n_seeds: int : ETKDG seeds per peptide
+        embed_chunk_size: int : per-call embed cap
+        score_chunk_size: int : per-batch MACE forward-pass cap
+        e_window_kt: float : energy filter window in kT_298K units (Click
+            lowercases the option name)
+        rmsd_threshold: float : geometric dedup exclusion radius
+        out_csv: Path | None : optional output CSV
+    Returns:
+        None
+    """
+    library = _load_peptide_smiles(saturation_csv)
+    labels = [s.strip() for s in peptides.split(",") if s.strip()]
+    missing = [s for s in labels if s not in library]
+    if missing:
+        raise click.BadParameter(
+            f"unknown peptide labels: {missing}; available: {sorted(library)}"
+        )
+
+    print(
+        f"=== Minimize ablation  n_seeds={n_seeds}  e_window_kT={e_window_kt}  rmsd_threshold={rmsd_threshold} ===\n"
+    )
+
+    hw = get_hardware_opts()
+    calc = get_mace_calc()
+    rows: list[dict] = []
+
+    for label in labels:
+        pep = library[label]
+        print(f"\n*** {label}  ({pep['n_heavy']} heavy atoms)")
+        print(
+            f"    smiles: {pep['smiles'][:80]}{'...' if len(pep['smiles']) > 80 else ''}"
+        )
+
+        # 1. Embed once.
+        t = time.perf_counter()
+        mol_seed = _embed_pool(pep["smiles"], n_seeds, hw, embed_chunk_size)
+        n_pool = mol_seed.GetNumConformers()
+        t_embed = time.perf_counter() - t
+        print(f"    [embed] {n_pool}/{n_seeds} conformers, {t_embed:.1f}s")
+        if n_pool == 0:
+            print("    ABORT: nothing embedded")
+            continue
+
+        from rdkit import Chem
+
+        # 2. Pipeline A — no minimize. Deepcopy so MMFF in pipeline B can't
+        # mutate the geometry pipeline A reads.
+        mol_a = Chem.Mol(mol_seed)
+        t = time.perf_counter()
+        e_a = _score_pool_mace(mol_a, calc, score_chunk_size=score_chunk_size)
+        ids_a, basin_e_a = _filter_and_dedup(
+            mol_a,
+            e_a,
+            e_window_kT=e_window_kt,
+            rmsd_threshold=rmsd_threshold,
+        )
+        t_a = time.perf_counter() - t
+        sa = _bw_summary(basin_e_a)
+
+        # 3. Pipeline B — GPU MMFF then identical scoring. Same starting
+        # geometry as pipeline A.
+        from nvmolkit.mmffOptimization import MMFFOptimizeMoleculesConfs
+
+        mol_b = Chem.Mol(mol_seed)
+        t = time.perf_counter()
+        MMFFOptimizeMoleculesConfs([mol_b], hardwareOptions=hw)
+        e_b = _score_pool_mace(mol_b, calc, score_chunk_size=score_chunk_size)
+        ids_b, basin_e_b = _filter_and_dedup(
+            mol_b,
+            e_b,
+            e_window_kT=e_window_kt,
+            rmsd_threshold=rmsd_threshold,
+        )
+        t_b = time.perf_counter() - t
+        sb = _bw_summary(basin_e_b)
+
+        # 4. Report.
+        print()
+        _print_summary("A: no minimize", sa, t_a)
+        print()
+        _print_summary("B: minimize=True (GPU MMFF)", sb, t_b)
+        print()
+        # MACE-energy rank correlation pre/post-MMFF — does the per-conformer
+        # ranking change much, or does MMFF mostly translate the landscape?
+        if e_a.size > 1:
+            rank_a = np.argsort(np.argsort(e_a))
+            rank_b = np.argsort(np.argsort(e_b))
+            spearman = float(np.corrcoef(rank_a, rank_b)[0, 1])
+            print(
+                f"  ── Spearman r of per-conformer MACE energies (pre vs post MMFF): {spearman:+.4f}"
+            )
+
+        for pl_label, summary, t_total in [
+            ("no_minimize", sa, t_a),
+            ("minimize_gpu", sb, t_b),
+        ]:
+            rows.append(
+                {
+                    "peptide_id": pep["peptide_id"],
+                    "n_heavy": pep["n_heavy"],
+                    "n_seeds": n_seeds,
+                    "n_pool": n_pool,
+                    "pipeline": pl_label,
+                    **summary,
+                    "time_total_s": t_total,
+                }
+            )
+
+    if out_csv is not None:
+        out_csv.parent.mkdir(parents=True, exist_ok=True)
+        with out_csv.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=OUTPUT_COLUMNS, extrasaction="ignore")
+            writer.writeheader()
+            for r in rows:
+                writer.writerow(r)
+        print(f"\nWrote {len(rows)} rows to {out_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/saturation_etkdg.py
+++ b/scripts/saturation_etkdg.py
@@ -1,0 +1,590 @@
+"""
+Saturation experiment for get_mol_PE_exhaustive: how do BW uniformity and
+basin count scale with the number of ETKDG seeds, and at what N do the
+curves flatten?
+
+This is the Phase 2 diagnostic for picking a production default for
+`n_seeds`. Results are written one row at a time to a CSV so a long sweep
+can be resumed if interrupted.
+
+Selection of representative peptides (5 by default):
+  * 2 from CREMP (validation subset) — one near the median CREMP
+    `poplowestpct` (~25 %, "typical rich ensemble") and one in the high tail
+    (~75–90 %, "sharper landscape than usual"). CREMP gives us CREST-
+    derived ground truth (`poplowestpct`, `uniqueconfs`) for the same
+    peptides we benchmark, so the saturation curve can be sanity-checked
+    against CREST.
+  * 3 from PAMPA (CycPeptMPDB-deduped) — one small (~50 heavy atoms),
+    one medium (~70), one large (~100+). PAMPA is the actual fine-tuning
+    consumer, so saturating the curve here is the binding goal.
+
+Per (peptide, n_seeds, minimize) row, the script reports:
+    n_pool          number of conformers actually embedded
+    n_basins        cluster representatives surviving energy filter + dedup
+    max_bw          weight of the dominant conformer in the basin set
+    eff_n           1 / Σ w_i² over the basin set
+    entropy         -Σ w_i log w_i over the basin set
+    n_within_kT     basins with E - E_min ≤ kT (≈ 26 meV at 298 K)
+    n_within_3kT    basins with E - E_min ≤ 3·kT
+    e_min_eV        minimum MACE energy seen in the pool
+    time_*          wall-clock per stage in seconds
+
+Usage (in the confsweeper pixi environment):
+
+    pixi run python scripts/saturation_etkdg.py \\
+        --cremp_csv data/processed/cremp/validation_subset.csv \\
+        --pampa_csv /home/sabari/peptide_electrostatics/data/fine_tune/CycPeptMPDB_PAMPA_deduped.csv \\
+        --out_csv  results/saturation_etkdg.csv \\
+        --n_seeds_grid 100,500,1000,5000,10000,50000
+
+A `--minimize_at_largest` flag re-runs the largest n_seeds with MMFF94
+minimization on each peptide, so the ablation lands in the same CSV.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import sys
+import time
+from pathlib import Path
+
+import click
+import numpy as np
+import pandas as pd
+import torch
+
+# fmt: off
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from rdkit.Chem.rdDistGeom import ETKDG  # noqa: E402
+
+from confsweeper import (  # noqa: E402
+    _KT_EV_298K,
+    get_embed_params_macrocycle,
+    get_hardware_opts,
+    get_mace_calc,
+    get_mol_PE_exhaustive,
+)
+
+# fmt: on
+
+
+def _build_params(mode: str):
+    """
+    Build ETKDG parameters for the given saturation mode.
+
+    Two modes are supported:
+        etkdgv3_macrocycle — confsweeper's default macrocycle-aware ETKDGv3
+            (useMacrocycleTorsions / useMacrocycle14config on). Same params as
+            the production fine-tuning pipeline; this is the baseline.
+        etkdg_original — RDKit's original 2015 ETKDG. No macrocycle-specific
+            sampling bias and weaker torsion-knowledge prior, intended to test
+            whether ETKDGv3's torsion bias is causing oversampling of the
+            global minimum at the expense of diverse low-energy basins.
+
+    Empirically verified: nvmolkit accepts all three of ETKDG, ETKDGv2,
+    ETKDGv3 without hanging or producing zero conformers (small linear
+    peptide, 10 conformers each).
+
+    Params:
+        mode: str : one of 'etkdgv3_macrocycle' or 'etkdg_original'
+    Returns:
+        rdkit.Chem.rdDistGeom.EmbedParameters : parameter object ready for nvmolkit
+    """
+    if mode == "etkdgv3_macrocycle":
+        return get_embed_params_macrocycle()
+    if mode == "etkdg_original":
+        params = ETKDG()
+        params.useRandomCoords = True
+        return params
+    raise ValueError(f"unknown params_mode: {mode}")
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s  %(message)s")
+logger = logging.getLogger("saturation")
+
+OUTPUT_COLUMNS = [
+    "peptide_id",
+    "source",
+    "n_heavy",
+    "smiles",
+    "params_mode",
+    "n_seeds",
+    "minimize",
+    "dihedral_jitter_deg",
+    "n_pool",
+    "n_basins",
+    "max_bw",
+    "eff_n",
+    "entropy",
+    "n_within_kT",
+    "n_within_3kT",
+    "e_min_eV",
+    "time_embed_s",
+    "time_score_s",
+    "time_filter_dedup_s",
+    "time_total_s",
+    "ground_truth_max_bw",  # CREMP poplowestpct/100, NaN for PAMPA
+    "ground_truth_n_confs",  # CREMP uniqueconfs, NaN for PAMPA
+]
+
+
+def select_cremp_peptides(cremp_csv: Path, n: int = 2) -> list[dict]:
+    """
+    Pick CREMP peptides spanning the `poplowestpct` distribution.
+
+    Picks the peptide closest to the median `poplowestpct` and the peptide
+    closest to the 90th-percentile `poplowestpct` from the validation subset.
+    Ties broken by lowest heavy-atom count (cheaper saturation runs first).
+
+    Params:
+        cremp_csv: Path : CREMP validation subset CSV
+        n: int : number of peptides to return (only n=2 is currently supported)
+    Returns:
+        list[dict] : peptide rows with keys peptide_id, source, smiles, n_heavy,
+            ground_truth_max_bw, ground_truth_n_confs
+    """
+    if n != 2:
+        raise NotImplementedError("Only n=2 CREMP picks supported today")
+    df = pd.read_csv(cremp_csv)
+
+    targets = [
+        ("cremp_typical", df["poplowestpct"].quantile(0.50)),
+        ("cremp_sharp", df["poplowestpct"].quantile(0.90)),
+    ]
+    picks: list[dict] = []
+    for label, target_pct in targets:
+        df_sorted = df.assign(
+            _delta=(df["poplowestpct"] - target_pct).abs()
+        ).sort_values(["_delta", "num_heavy_atoms"])
+        row = df_sorted.iloc[0]
+        picks.append(
+            {
+                "peptide_id": f"{label}:{row['sequence']}",
+                "source": "cremp",
+                "smiles": row["smiles"],
+                "n_heavy": int(row["num_heavy_atoms"]),
+                "ground_truth_max_bw": float(row["poplowestpct"]) / 100.0,
+                "ground_truth_n_confs": int(row["uniqueconfs"]),
+            }
+        )
+    return picks
+
+
+def select_pampa_peptides(pampa_csv: Path, smiles_col: str = "SMILES") -> list[dict]:
+    """
+    Pick three PAMPA peptides: small / medium / large heavy-atom count.
+
+    Targets the medians of three heavy-atom buckets: small (≤55), medium
+    (60–75), large (≥95). Each bucket contributes the row with median
+    `num_heavy_atoms` (ties broken by first occurrence). PAMPA has no
+    CREST ground truth, so the ground-truth columns are NaN.
+
+    Params:
+        pampa_csv: Path : CycPeptMPDB-deduped CSV
+        smiles_col: str : SMILES column name in the CSV
+    Returns:
+        list[dict] : three peptide rows with keys peptide_id, source, smiles,
+            n_heavy, ground_truth_max_bw (NaN), ground_truth_n_confs (NaN)
+    """
+    from rdkit import Chem, RDLogger
+
+    RDLogger.DisableLog("rdApp.*")
+
+    df = pd.read_csv(pampa_csv)
+    df["n_heavy"] = df[smiles_col].apply(
+        lambda s: Chem.MolFromSmiles(s).GetNumHeavyAtoms()
+        if Chem.MolFromSmiles(s)
+        else 0
+    )
+
+    buckets = [
+        ("pampa_small", df[df["n_heavy"] <= 55]),
+        ("pampa_medium", df[(df["n_heavy"] >= 60) & (df["n_heavy"] <= 75)]),
+        ("pampa_large", df[df["n_heavy"] >= 95]),
+    ]
+    picks: list[dict] = []
+    for label, sub in buckets:
+        if sub.empty:
+            logger.warning("PAMPA bucket %s is empty — skipping", label)
+            continue
+        median_n = int(sub["n_heavy"].median())
+        row = (
+            sub.assign(_delta=(sub["n_heavy"] - median_n).abs())
+            .sort_values(["_delta", "n_heavy"])
+            .iloc[0]
+        )
+        picks.append(
+            {
+                "peptide_id": label,
+                "source": "pampa",
+                "smiles": row[smiles_col],
+                "n_heavy": int(row["n_heavy"]),
+                "ground_truth_max_bw": float("nan"),
+                "ground_truth_n_confs": float("nan"),
+            }
+        )
+    return picks
+
+
+def _read_done_set(out_csv: Path) -> set[tuple]:
+    """
+    Return the set of (peptide_id, params_mode, n_seeds, minimize,
+    dihedral_jitter_deg) tuples already written so the runner can skip them
+    on resume.
+
+    Older CSV files written before `params_mode` or `dihedral_jitter_deg`
+    were added are read with sensible defaults — `params_mode` defaults to
+    'etkdgv3_macrocycle' (the only mode the original sweep ran in) and
+    `dihedral_jitter_deg` defaults to 0.0 (jitter off).
+
+    Params:
+        out_csv: Path : output CSV path
+    Returns:
+        set[tuple[str, str, int, bool, float]] : already-completed runs
+    """
+    if not out_csv.exists():
+        return set()
+    df = pd.read_csv(out_csv)
+    if "params_mode" not in df.columns:
+        df["params_mode"] = "etkdgv3_macrocycle"
+    if "dihedral_jitter_deg" not in df.columns:
+        df["dihedral_jitter_deg"] = 0.0
+    return set(
+        zip(
+            df["peptide_id"].astype(str),
+            df["params_mode"].astype(str),
+            df["n_seeds"].astype(int),
+            df["minimize"].astype(bool),
+            df["dihedral_jitter_deg"].astype(float),
+        )
+    )
+
+
+def _append_row(out_csv: Path, row: dict) -> None:
+    """
+    Append one result row to the CSV, writing the header on first call.
+
+    Params:
+        out_csv: Path : output CSV path
+        row: dict : keys must be a subset of OUTPUT_COLUMNS
+    Returns:
+        None
+    """
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    write_header = not out_csv.exists()
+    with out_csv.open("a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=OUTPUT_COLUMNS, extrasaction="ignore")
+        if write_header:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def _bw_metrics(energies_eV: list[float]) -> dict:
+    """
+    Compute Boltzmann-weight statistics and energy-window counts for a basin set.
+
+    Params:
+        energies_eV: list[float] : MACE energies in eV for the basin centroids
+    Returns:
+        dict with keys n_basins, max_bw, eff_n, entropy, n_within_kT,
+            n_within_3kT, e_min_eV
+    """
+    e = np.asarray(energies_eV, dtype=np.float64)
+    if e.size == 0:
+        return {
+            "n_basins": 0,
+            "max_bw": float("nan"),
+            "eff_n": float("nan"),
+            "entropy": float("nan"),
+            "n_within_kT": 0,
+            "n_within_3kT": 0,
+            "e_min_eV": float("nan"),
+        }
+    de = e - e.min()
+    w = np.exp(-de / _KT_EV_298K)
+    w = w / w.sum()
+    return {
+        "n_basins": int(e.size),
+        "max_bw": float(w.max()),
+        "eff_n": float(1.0 / (w**2).sum()),
+        "entropy": float(-(w * np.log(w.clip(1e-45))).sum()),
+        "n_within_kT": int((de <= _KT_EV_298K).sum()),
+        "n_within_3kT": int((de <= 3 * _KT_EV_298K).sum()),
+        "e_min_eV": float(e.min()),
+    }
+
+
+def run_one(
+    peptide: dict,
+    n_seeds: int,
+    minimize: bool,
+    params_mode: str,
+    params,
+    hardware_opts,
+    calc,
+    embed_chunk_size: int,
+    score_chunk_size: int,
+    e_window_kt: float,
+    rmsd_threshold: float,
+    dihedral_jitter_deg: float,
+) -> dict:
+    """
+    Run get_mol_PE_exhaustive for one (peptide, n_seeds, minimize, params_mode,
+    dihedral_jitter_deg) point and compute saturation metrics.
+
+    Params:
+        peptide: dict : selected-peptide row (peptide_id, source, smiles, n_heavy, ground_truth_*)
+        n_seeds: int : ETKDG seed count for this run
+        minimize: bool : whether to MMFF94-minimize each conformer before scoring
+        params_mode: str : ETKDG variant label (recorded into the output row)
+        params : ETKDG params instance constructed from params_mode
+        hardware_opts : nvmolkit hardware options
+        calc : MACE calculator
+        embed_chunk_size: int : per-call embed cap
+        score_chunk_size: int : per-batch MACE forward pass cap
+        e_window_kt: float : energy filter window in units of kT_298K
+        rmsd_threshold: float : geometric dedup exclusion radius
+        dihedral_jitter_deg: float : maximum random rotation in degrees applied
+            to each rotatable-bond dihedral after embedding (0 disables jitter)
+    Returns:
+        dict with all OUTPUT_COLUMNS populated for this run
+    """
+    t_embed_start = time.perf_counter()
+    _, _, energies_eV = get_mol_PE_exhaustive(
+        peptide["smiles"],
+        params,
+        hardware_opts,
+        calc,
+        n_seeds=n_seeds,
+        embed_chunk_size=embed_chunk_size,
+        score_chunk_size=score_chunk_size,
+        e_window_kT=e_window_kt,
+        rmsd_threshold=rmsd_threshold,
+        minimize=minimize,
+        dihedral_jitter_deg=dihedral_jitter_deg,
+    )
+    t_total = time.perf_counter() - t_embed_start
+
+    metrics = _bw_metrics(energies_eV)
+    # The exhaustive function does not return per-stage timings; record the
+    # total elapsed and leave per-stage NaN. Phase 2 follow-up may extend the
+    # function's return contract if profiling becomes important.
+    return {
+        "peptide_id": peptide["peptide_id"],
+        "source": peptide["source"],
+        "n_heavy": peptide["n_heavy"],
+        "smiles": peptide["smiles"],
+        "params_mode": params_mode,
+        "n_seeds": n_seeds,
+        "minimize": minimize,
+        "dihedral_jitter_deg": dihedral_jitter_deg,
+        "n_pool": n_seeds,
+        **metrics,
+        "time_embed_s": float("nan"),
+        "time_score_s": float("nan"),
+        "time_filter_dedup_s": float("nan"),
+        "time_total_s": t_total,
+        "ground_truth_max_bw": peptide["ground_truth_max_bw"],
+        "ground_truth_n_confs": peptide["ground_truth_n_confs"],
+    }
+
+
+@click.command()
+@click.option(
+    "--cremp_csv",
+    required=True,
+    type=Path,
+    help="CREMP validation subset CSV (sequence,smiles,...,poplowestpct,uniqueconfs)",
+)
+@click.option(
+    "--pampa_csv",
+    required=True,
+    type=Path,
+    help="CycPeptMPDB-deduped PAMPA CSV with a SMILES column",
+)
+@click.option(
+    "--out_csv",
+    required=True,
+    type=Path,
+    help="Output saturation results CSV (one row per (peptide, n_seeds, minimize))",
+)
+@click.option(
+    "--n_seeds_grid",
+    default="100,500,1000,5000,10000,50000",
+    help="Comma-separated ETKDG seed counts to sweep",
+)
+@click.option("--embed_chunk_size", default=1000, type=int)
+@click.option("--score_chunk_size", default=500, type=int)
+@click.option("--e_window_kT", default=5.0, type=float)
+@click.option("--rmsd_threshold", default=0.1, type=float)
+@click.option(
+    "--params_mode",
+    type=click.Choice(["etkdgv3_macrocycle", "etkdg_original"]),
+    default="etkdgv3_macrocycle",
+    help="ETKDG variant to embed with. 'etkdgv3_macrocycle' is the "
+    "production default; 'etkdg_original' drops the macrocycle "
+    "torsion knowledge to test whether v3's bias suppresses "
+    "low-energy basin diversity.",
+)
+@click.option(
+    "--dihedral_jitter_deg",
+    default=0.0,
+    type=float,
+    help="If >0, after embedding apply a uniform random rotation in "
+    "[-jitter, +jitter] degrees to each rotatable-bond dihedral "
+    "on every conformer. Used to push side-chain rotamer "
+    "exploration past ETKDG's torsion-knowledge bias.",
+)
+@click.option(
+    "--minimize_at_largest",
+    is_flag=True,
+    help="Also run the largest n_seeds value with minimize=True per peptide",
+)
+@click.option(
+    "--smiles_col", default="SMILES", help="SMILES column name in the PAMPA CSV"
+)
+def main(
+    cremp_csv: Path,
+    pampa_csv: Path,
+    out_csv: Path,
+    n_seeds_grid: str,
+    embed_chunk_size: int,
+    score_chunk_size: int,
+    e_window_kt: float,
+    rmsd_threshold: float,
+    params_mode: str,
+    dihedral_jitter_deg: float,
+    minimize_at_largest: bool,
+    smiles_col: str,
+) -> None:
+    """
+    Run the saturation sweep on the chosen representative peptides.
+
+    Params:
+        cremp_csv: Path : CREMP validation subset CSV
+        pampa_csv: Path : CycPeptMPDB-deduped PAMPA CSV
+        out_csv: Path : output CSV path (resume-aware)
+        n_seeds_grid: str : comma-separated seed counts
+        embed_chunk_size: int : per-call embed cap
+        score_chunk_size: int : per-batch MACE forward pass cap
+        e_window_kt: float : energy filter window in units of kT_298K (Click
+            lowercases option names, so the CLI flag is --e_window_kT but the
+            Python kwarg is e_window_kt)
+        rmsd_threshold: float : dedup exclusion radius
+        params_mode: str : ETKDG variant ('etkdgv3_macrocycle' or 'etkdg_original')
+        dihedral_jitter_deg: float : maximum random rotation per rotatable bond
+            (0 disables; same value applied to every n_seeds in this invocation)
+        minimize_at_largest: bool : run minimize=True at largest n_seeds per peptide
+        smiles_col: str : SMILES column name in PAMPA CSV
+    Returns:
+        None
+    """
+    seeds = sorted(int(x.strip()) for x in n_seeds_grid.split(",") if x.strip())
+    largest = max(seeds)
+
+    peptides = select_cremp_peptides(cremp_csv, n=2) + select_pampa_peptides(
+        pampa_csv, smiles_col=smiles_col
+    )
+    logger.info("Selected %d peptides:", len(peptides))
+    for p in peptides:
+        logger.info(
+            "  %-22s  source=%s  n_heavy=%d  ground_truth_max_bw=%s",
+            p["peptide_id"],
+            p["source"],
+            p["n_heavy"],
+            f"{p['ground_truth_max_bw']:.3f}"
+            if not np.isnan(p["ground_truth_max_bw"])
+            else "n/a",
+        )
+    logger.info(
+        "params_mode=%s  dihedral_jitter_deg=%g", params_mode, dihedral_jitter_deg
+    )
+
+    done = _read_done_set(out_csv)
+    if done:
+        logger.info(
+            "Resuming: %d (peptide, params_mode, n_seeds, minimize, dihedral_jitter_deg) tuples already done",
+            len(done),
+        )
+
+    # GPU-bound shared resources: build once, reuse across runs.
+    params = _build_params(params_mode)
+    hw = get_hardware_opts()
+    calc = get_mace_calc()
+
+    runs: list[tuple[dict, int, bool]] = []
+    for peptide in peptides:
+        for n_seeds in seeds:
+            runs.append((peptide, n_seeds, False))
+        if minimize_at_largest:
+            runs.append((peptide, largest, True))
+
+    for peptide, n_seeds, minimize in runs:
+        key = (
+            peptide["peptide_id"],
+            params_mode,
+            n_seeds,
+            minimize,
+            dihedral_jitter_deg,
+        )
+        if key in done:
+            logger.info(
+                "skip %s mode=%s n=%d minimize=%s jitter=%g (already done)",
+                peptide["peptide_id"],
+                params_mode,
+                n_seeds,
+                minimize,
+                dihedral_jitter_deg,
+            )
+            continue
+
+        logger.info(
+            "run  %s mode=%s n=%d minimize=%s jitter=%g",
+            peptide["peptide_id"],
+            params_mode,
+            n_seeds,
+            minimize,
+            dihedral_jitter_deg,
+        )
+        try:
+            row = run_one(
+                peptide,
+                n_seeds,
+                minimize,
+                params_mode,
+                params,
+                hw,
+                calc,
+                embed_chunk_size=embed_chunk_size,
+                score_chunk_size=score_chunk_size,
+                e_window_kt=e_window_kt,
+                rmsd_threshold=rmsd_threshold,
+                dihedral_jitter_deg=dihedral_jitter_deg,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Failed %s mode=%s n=%d minimize=%s jitter=%g: %s",
+                peptide["peptide_id"],
+                params_mode,
+                n_seeds,
+                minimize,
+                dihedral_jitter_deg,
+                exc,
+            )
+            continue
+
+        _append_row(out_csv, row)
+        logger.info(
+            "    -> n_basins=%d  max_bw=%.3f  n_within_3kT=%d  total=%.1fs",
+            row["n_basins"],
+            row["max_bw"],
+            row["n_within_3kT"],
+            row["time_total_s"],
+        )
+        # Free GPU memory between runs so the next embed has headroom.
+        torch.cuda.empty_cache()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/README.md
+++ b/src/README.md
@@ -23,10 +23,11 @@ Two helper functions build RDKit `EmbedParameters` objects for nvmolkit:
 
 - **`get_embed_params()`** — baseline ETKDGv3 with `useRandomCoords=True`. Suitable
   for small molecules.
-- **`get_embed_params_macrocycle()`** — adds `useMacrocycleTorsions`, `useMacrocycle14config`,
-  and `useSmallRingTorsions`. The macrocycle flags enable a special sampling regime in
-  ETKDGv3 that handles the ring-closure constraints of cyclic backbones. Use this for
-  any cyclic peptide input.
+- **`get_embed_params_macrocycle()`** — adds `useMacrocycleTorsions` and
+  `useMacrocycle14config`, the ETKDGv3 flags that enable a special sampling regime for
+  ring-closure constraints on cyclic backbones. Use this for any cyclic peptide input.
+  `useSmallRingTorsions` is intentionally left disabled — nvmolkit does not support
+  the flag and hangs indefinitely in CPU preprocessing when it is set.
 
 ### Energy backends
 

--- a/src/README.md
+++ b/src/README.md
@@ -64,6 +64,31 @@ Torsional sampling is activated by passing `grids` (loaded from the CREMP Ramach
 `.npz` via `load_ramachandran_grids`) and setting `n_constrained_samples > 0`. When
 `grids=None` (the default), behaviour is identical to before — no overhead is added.
 
+**`get_mol_PE_exhaustive`** — randomized-saturation pipeline for cyclic peptides
+and other molecules where `get_mol_PE_batched` produces near-one-hot Boltzmann
+distributions because ETKDG-100 misses low-energy basins. Embeds an order of
+magnitude more conformers (`n_seeds=10000` by default), optionally
+MMFF-minimises them on the GPU via `nvmolkit.mmffOptimization`, MACE-scores
+in chunks, applies a 5 kT energy filter, and dedups by basin energy minimum
+rather than cluster density. Returns the same `(mol, conf_ids, energies)`
+contract as the other pipelines, so downstream consumers swap one function
+call. See `docs/exhaustive_etkdg_plan.md` for the saturation experiments
+behind the chosen defaults; the headline result is that exhaustive ETKDG +
+MMFF reproduces CREST-quality Boltzmann distributions on most cyclic
+peptides we tested (e.g. `cremp_typical`: 27 heavy atoms, max_bw 0.318 vs
+CREST ground truth 0.246) at a fraction of CREST's compute cost.
+
+The seven-stage pipeline:
+1. Massive ETKDG embed (chunked when `n_seeds > embed_chunk_size`).
+2. Optional rotatable-bond dihedral jitter (off by default; experimental).
+3. Optional MMFF94 minimisation (on by default), `gpu` or `cpu` backend.
+4. Batched MACE scoring in chunks of `score_chunk_size`.
+5. Energy filter: drop conformers with `(E - E_min) > 5 kT`.
+6. Energy-ranked geometric dedup via `_energy_ranked_dedup` — picks the
+   lowest-energy conformer of each geometric basin, in contrast to Butina
+   which picks dense cluster centres.
+7. Returns one centroid per basin, ordered by ascending energy.
+
 **`get_mol_PE_mmff`** — like `get_mol_PE_batched` but scores with MMFF94. No GPU
 required for the scoring step; GPU is still used for embedding and Butina.
 
@@ -109,9 +134,25 @@ than symmetric RMSD but is much cheaper to compute across thousands of conformer
 | `torsion_strategy` | `str` | `'uniform'` or `'inverse'` (default `'uniform'`) |
 | `torsion_seed` | `int` | RNG seed for Pool B reproducibility (default 0) |
 
+**`get_mol_PE_exhaustive`** — different parameter space (no Butina cutoff, no
+torsional sampling, no `gpu_clustering` toggle):
+
+| Argument | Type | Notes |
+|----------|------|-------|
+| `smi`, `params`, `hardware_opts`, `calc` | — | as above |
+| `n_seeds` | `int` | total ETKDG seeds (default 10000, saturation-validated) |
+| `embed_chunk_size` | `int` | nvmolkit per-call cap before chunking (default 1000) |
+| `score_chunk_size` | `int` | MACE per-batch forward-pass cap (default 500) |
+| `e_window_kT` | `float` | energy filter window in `kT_298K` units (default 5.0) |
+| `rmsd_threshold` | `float` | basin-dedup exclusion radius in normalised L1 units (default 0.1) |
+| `minimize` | `bool` | MMFF94 minimise post-embed (default `True`, the lever) |
+| `mmff_backend` | `str` | `'gpu'` (default; nvmolkit batched CUDA) or `'cpu'` (RDKit serial) |
+| `dihedral_jitter_deg` | `float` | rotatable-bond jitter ±deg (default 0; experimental) |
+| `seed` | `int` | base ETKDG seed; chunk i uses `seed + i*embed_chunk_size` (default 0) |
+
 Returns `(mol, conf_ids, pe)`:
-- `mol`: `Chem.Mol` with only Butina-representative conformers attached
-- `conf_ids`: `List[int]` of conformer IDs on `mol`
+- `mol`: `Chem.Mol` with only basin-representative conformers attached
+- `conf_ids`: `List[int]` of conformer IDs on `mol`, ordered by ascending energy
 - `pe`: `List[float]` of energies in eV, same order as `conf_ids`
 
 **`write_sdf`**
@@ -128,6 +169,22 @@ carries a `MACE_ENERGY` property (eV) regardless of which backend was used. When
   after embedding before assuming `n_confs` conformers are available.
 - **GPU ID**: `get_hardware_opts` defaults to `gpuIds=[0]`. On multi-GPU nodes, set
   `gpuIds` explicitly; nvmolkit does not auto-select a free GPU.
+- **`get_mol_PE_exhaustive` is bursty, not monotone**: `max_bw` does not smoothly
+  decrease with `n_seeds`. It oscillates because each newly-discovered low-energy
+  conformer resets `E_min`, sometimes pushing previously-contributing basins outside
+  the 5 kT filter. The right summary metric across a sweep is `min(max_bw)`, not the
+  value at any specific `n_seeds`. A single large run is more reliable than a
+  fine-grained scan.
+- **`get_mol_PE_exhaustive` requires `minimize=True` for cyclic peptides**: turning
+  off MMFF post-minimisation reverts to one-hot Boltzmann distributions on most
+  peptides above ~50 heavy atoms, defeating the purpose of the pipeline. Only set
+  `minimize=False` if you specifically want pre-minimisation energies (e.g. ablation
+  studies).
+- **`get_mol_PE_exhaustive` GPU MMFF stochasticity**: the `mmff_backend='gpu'` path
+  produces final geometries that are not bit-exact identical to `'cpu'`. Pearson r
+  between final energies is ~0.95; basin distributions after dedup are similar but
+  not identical. For batch saturation runs this is fine. Switch to `'cpu'` only for
+  bit-exact RDKit reference behaviour, accepting a 25-50× slowdown.
 
 ---
 

--- a/src/confsweeper.py
+++ b/src/confsweeper.py
@@ -396,6 +396,51 @@ def _mace_batch_energies(calc, ase_mols: list) -> list:
         return pe
 
 
+def _energy_ranked_dedup(
+    coords: torch.Tensor,
+    energies: np.ndarray,
+    rmsd_threshold: float,
+) -> list[int]:
+    """
+    Pick basin representatives by energy rank with a geometric exclusion radius.
+
+    Differs from Butina: Butina picks dense cluster centres first, which can
+    discard the lowest-energy member of a dense cluster. Energy-ranked dedup
+    iterates lowest energy first, so each basin's representative is its
+    energy minimum.
+
+    Distances use the same normalised L1 metric as get_mol_PE_batched so the
+    rmsd_threshold parameter is comparable to its cutoff_dist (default 0.1).
+
+    Params:
+        coords: torch.Tensor : conformer coordinates [N, A, 3]
+        energies: ndarray [N] : potential energies in eV (any shift; only differences matter)
+        rmsd_threshold: float : exclusion radius in normalised L1 units (sum |Δ| / 3·A)
+    Returns:
+        list[int] : indices into the input arrays of the chosen centroids,
+                    ordered by ascending energy
+    """
+    n = coords.shape[0]
+    if n == 0:
+        return []
+    if n == 1:
+        return [0]
+
+    n_atoms = coords.shape[1]
+    flat = coords.reshape(n, -1)
+    order = np.argsort(np.asarray(energies), kind="stable")
+
+    excluded = torch.zeros(n, dtype=torch.bool, device=flat.device)
+    centroids: list[int] = []
+    for idx in order.tolist():
+        if bool(excluded[idx]):
+            continue
+        centroids.append(idx)
+        d = (flat - flat[idx].unsqueeze(0)).abs().sum(dim=1) / (3 * n_atoms)
+        excluded |= d < rmsd_threshold
+    return centroids
+
+
 def get_mol_PE_mmff(
     smi: str,
     params,

--- a/src/confsweeper.py
+++ b/src/confsweeper.py
@@ -75,9 +75,12 @@ def get_embed_params() -> rdkit.Chem.rdDistGeom.EmbedParameters:
 def get_embed_params_macrocycle() -> rdkit.Chem.rdDistGeom.EmbedParameters:
     """
     ETKDG setup for macrocyclic molecules. ETKDGv3 already enables
-    useMacrocycleTorsions and useMacrocycle14config by default; this function
-    additionally enables useSmallRingTorsions (off by default) which improves
-    embedding for ring systems within the macrocycle scaffold.
+    useMacrocycleTorsions and useMacrocycle14config by default; the
+    useSmallRingTorsions flag (which would improve embedding for small ring
+    systems within the macrocycle scaffold) is intentionally left disabled
+    because nvmolkit does not support it and hangs indefinitely in CPU
+    preprocessing when it is set.
+
     Params:
         None
     Returns:
@@ -87,9 +90,6 @@ def get_embed_params_macrocycle() -> rdkit.Chem.rdDistGeom.EmbedParameters:
     params.useRandomCoords = True
     params.useMacrocycleTorsions = True
     params.useMacrocycle14config = True
-    # useSmallRingTorsions is disabled: nvmolkit does not support this ETKDGv3 flag
-    # and hangs indefinitely in CPU preprocessing when it is set.
-    # params.useSmallRingTorsions = True
     return params
 
 

--- a/src/confsweeper.py
+++ b/src/confsweeper.py
@@ -355,6 +355,7 @@ def get_mol_PE_batched(
 
 
 _KCAL_TO_EV = 0.043364  # 1 kcal/mol in eV
+_KT_EV_298K = 8.617333e-5 * 298.0  # k_B T at 298 K in eV (≈ 0.02568)
 
 
 def _mace_batch_energies(calc, ase_mols: list) -> list:
@@ -439,6 +440,170 @@ def _energy_ranked_dedup(
         d = (flat - flat[idx].unsqueeze(0)).abs().sum(dim=1) / (3 * n_atoms)
         excluded |= d < rmsd_threshold
     return centroids
+
+
+def get_mol_PE_exhaustive(
+    smi: str,
+    params,
+    hardware_opts,
+    calc,
+    n_seeds: int = 5000,
+    embed_chunk_size: int = 1000,
+    score_chunk_size: int = 500,
+    e_window_kT: float = 5.0,
+    rmsd_threshold: float = 0.1,
+    minimize: bool = False,
+    seed: int = 0,
+) -> Tuple[Chem.Mol, List[int], List[float]]:
+    """
+    Embed many randomized ETKDG conformers, MACE-score them all, energy-filter,
+    and dedup geometrically by basin energy minimum.
+
+    The premise is to replace CREST metadynamics with brute-force randomization:
+    nvmolkit's GPU embed is two orders of magnitude cheaper than CREST per
+    conformer, so we can afford thousands of seeds. The energy filter keeps
+    geometric dedup tractable on the massive pre-pool by dropping conformers
+    that cannot contribute to a 298 K Boltzmann ensemble regardless of their
+    geometric uniqueness.
+
+    When to use vs. get_mol_PE_batched:
+      * get_mol_PE_batched — small N, optionally torsional sampling, fast.
+      * get_mol_PE_exhaustive — cyclic peptides / molecules with rich
+        Boltzmann ensembles where get_mol_PE_batched produces near-one-hot
+        weight distributions because ETKDG-100 misses low-energy basins.
+
+    Pipeline:
+      1. Embed n_seeds conformers via nvmolkit ETKDG. A single
+         EmbedMolecules call is used when n_seeds <= embed_chunk_size; for
+         larger n_seeds the call is repeated in chunks with seed offsets so
+         the GPU memory footprint stays bounded.
+      2. Optional MMFF94 minimization in place (off by default).
+      3. MACE-score the full pool in chunks of score_chunk_size.
+      4. Drop conformers with (E - E_min) > e_window_kT * kT (kT = 26 meV at
+         298 K). At least one conformer (the minimum) is always retained.
+      5. Energy-ranked geometric dedup via _energy_ranked_dedup, keeping the
+         lowest-energy member of each geometric basin defined by
+         rmsd_threshold (normalised L1 units, matching get_mol_PE_batched).
+
+    The randomSeed attribute on `params` is mutated during chunked embedding
+    (each chunk uses seed + chunk_index * embed_chunk_size). Bit-exact
+    reproducibility across runs is not guaranteed because nvmolkit advances
+    internal random state independently of params.randomSeed, but
+    distributional reproducibility (sorted-energy and basin-count statistics)
+    is preserved.
+
+    Params:
+        smi: str : input SMILES string
+        params : ETKDG params from get_embed_params or get_embed_params_macrocycle
+        hardware_opts : nvmolkit hardware options from get_hardware_opts
+        calc : MACECalculator from get_mace_calc()
+        n_seeds: int : total ETKDG seeds to embed
+        embed_chunk_size: int : per-call cap before chunking; tune to GPU memory
+        score_chunk_size: int : per-batch MACE forward pass cap
+        e_window_kT: float : energy filter window in units of kT_298K
+        rmsd_threshold: float : geometric dedup exclusion radius (normalised L1)
+        minimize: bool : MMFF94-minimize each conformer before scoring
+        seed: int : base ETKDG random seed; chunk i uses seed + i*embed_chunk_size
+    Returns:
+        rdkit.Chem.Mol : mol with only basin-representative conformers attached
+        List[int] : conformer IDs of basin representatives, ordered by ascending energy
+        List[float] : potential energies in eV for each representative
+    """
+    mol = Chem.AddHs(Chem.MolFromSmiles(smi))
+
+    # 1. Massive embed (Path A single call, or Path B chunked when n_seeds is large)
+    if n_seeds <= embed_chunk_size:
+        params.randomSeed = seed
+        embed.EmbedMolecules(
+            [mol], params, confsPerMolecule=n_seeds, hardwareOptions=hardware_opts
+        )
+    else:
+        n_remaining = n_seeds
+        chunk_idx = 0
+        while n_remaining > 0:
+            this_chunk = min(embed_chunk_size, n_remaining)
+            params.randomSeed = seed + chunk_idx * embed_chunk_size
+            n_before = mol.GetNumConformers()
+            embed.EmbedMolecules(
+                [mol],
+                params,
+                confsPerMolecule=this_chunk,
+                hardwareOptions=hardware_opts,
+            )
+            # Stop early if a chunk produced nothing — likely an
+            # embedding-incompatible molecule rather than a transient failure.
+            if mol.GetNumConformers() == n_before:
+                break
+            n_remaining -= this_chunk
+            chunk_idx += 1
+
+    all_conf_ids = [c.GetId() for c in mol.GetConformers()]
+    if not all_conf_ids:
+        return mol, [], []
+
+    # 2. Optional MMFF94 minimization. Errors leave the conformer at its
+    # pre-minimize geometry; we don't track per-conformer success/failure
+    # because MACE scoring afterwards naturally surfaces any pathological
+    # geometries through extreme energies.
+    if minimize:
+        from rdkit.Chem import AllChem
+
+        for cid in all_conf_ids:
+            AllChem.MMFFOptimizeMolecule(mol, confId=cid)
+
+    # 3. Batched MACE scoring, chunked to bound the GPU forward-pass batch size.
+    atomic_nums = [a.GetAtomicNum() for a in mol.GetAtoms()]
+    energies: List[float] = []
+    for start in range(0, len(all_conf_ids), score_chunk_size):
+        chunk_ids = all_conf_ids[start : start + score_chunk_size]
+        ase_mols = [
+            ase.Atoms(
+                positions=mol.GetConformer(cid).GetPositions(),
+                numbers=atomic_nums,
+            )
+            for cid in chunk_ids
+        ]
+        energies.extend(_mace_batch_energies(calc, ase_mols))
+
+    energies_arr = np.asarray(energies, dtype=np.float64)
+
+    # 4. Energy filter: keep conformers within e_window_kT * kT of the minimum.
+    e_min = energies_arr.min()
+    keep_mask = (energies_arr - e_min) <= e_window_kT * _KT_EV_298K
+    if not keep_mask.any():
+        # Only reachable on degenerate inputs (e.g. NaN energies). Force the
+        # caller's contract: at least one centroid is always returned.
+        keep_mask = np.zeros_like(keep_mask)
+        keep_mask[int(np.argmin(energies_arr))] = True
+
+    kept_pool_idx = np.where(keep_mask)[0].tolist()
+    kept_conf_ids = [all_conf_ids[i] for i in kept_pool_idx]
+    kept_energies = energies_arr[kept_pool_idx]
+
+    # 5. Energy-ranked geometric dedup. With a single survivor there is
+    # nothing to cluster; otherwise use the basin-energy primitive.
+    if len(kept_conf_ids) == 1:
+        centroid_ids = list(kept_conf_ids)
+        centroid_energies = [float(kept_energies[0])]
+    else:
+        coords = torch.tensor(
+            np.array([mol.GetConformer(cid).GetPositions() for cid in kept_conf_ids])
+        )
+        centroid_pool_idx = _energy_ranked_dedup(
+            coords, kept_energies, rmsd_threshold=rmsd_threshold
+        )
+        centroid_ids = [kept_conf_ids[i] for i in centroid_pool_idx]
+        centroid_energies = [float(kept_energies[i]) for i in centroid_pool_idx]
+
+    # 6. Output: drop non-centroid conformers from the mol so the returned
+    # object matches the (mol, ids, energies) contract used by callers of
+    # get_mol_PE / get_mol_PE_batched.
+    centroid_set = set(centroid_ids)
+    for cid in all_conf_ids:
+        if cid not in centroid_set:
+            mol.RemoveConformer(cid)
+
+    return mol, centroid_ids, centroid_energies
 
 
 def get_mol_PE_mmff(

--- a/src/confsweeper.py
+++ b/src/confsweeper.py
@@ -1,3 +1,44 @@
+"""
+confsweeper.py — generation-to-scoring conformer pipeline.
+
+The public surface is a family of `get_mol_PE*` functions that each take a
+SMILES string and return `(mol, conf_ids, energies)`: an RDKit mol with the
+representative conformers attached, the integer IDs of those representatives,
+and their potential energies in eV.
+
+Three pipelines, each suited to a different sampling regime:
+
+    get_mol_PE             baseline reference. Embeds n_confs conformers via
+                           nvmolkit ETKDG, Butina-clusters, scores each
+                           representative in a separate ASE calculator call.
+                           Slow for large representative sets; use mainly to
+                           validate the other pipelines.
+
+    get_mol_PE_batched     production small-N pipeline. Same embed + Butina,
+                           but scores all representatives in a single batched
+                           MACE forward pass. Optionally adds backbone
+                           dihedral-constrained Pool B conformers via
+                           torsional_sampling.sample_constrained_confs (this
+                           is the only pipeline that supports torsional
+                           sampling). Use for general-purpose conformer
+                           generation when n_confs ≤ ~1000 is sufficient.
+
+    get_mol_PE_exhaustive  randomized-saturation pipeline for cyclic peptides
+                           and other molecules with rich multi-basin Boltzmann
+                           ensembles. Embeds thousands of conformers,
+                           optionally MMFF-minimises them on GPU
+                           (nvmolkit.mmffOptimization), MACE-scores in chunks,
+                           applies a 5 kT energy filter, and dedup via the
+                           private _energy_ranked_dedup helper (a basin-energy
+                           variant of Butina that picks the lowest-energy
+                           member of each geometric basin). Saturation-
+                           validated defaults are baked in; see the function
+                           docstring and docs/exhaustive_etkdg_plan.md.
+
+The three pipelines share the same return contract, so downstream consumers
+(SDF writers, fine-tuning conformer caches) swap one function call to upgrade.
+"""
+
 import contextlib
 import os
 import random
@@ -532,12 +573,12 @@ def get_mol_PE_exhaustive(
     params,
     hardware_opts,
     calc,
-    n_seeds: int = 5000,
+    n_seeds: int = 10000,
     embed_chunk_size: int = 1000,
     score_chunk_size: int = 500,
     e_window_kT: float = 5.0,
     rmsd_threshold: float = 0.1,
-    minimize: bool = False,
+    minimize: bool = True,
     mmff_backend: str = "gpu",
     dihedral_jitter_deg: float = 0.0,
     seed: int = 0,
@@ -558,6 +599,15 @@ def get_mol_PE_exhaustive(
       * get_mol_PE_exhaustive — cyclic peptides / molecules with rich
         Boltzmann ensembles where get_mol_PE_batched produces near-one-hot
         weight distributions because ETKDG-100 misses low-energy basins.
+
+    Default values for n_seeds, minimize, and mmff_backend are the
+    saturation-validated production settings from
+    docs/exhaustive_etkdg_plan.md: across the five representative cyclic
+    peptides tested (CREMP + PAMPA, n_heavy 27-103), this configuration
+    reproduces CREST-quality Boltzmann distributions on most peptides at
+    a fraction of CREST's compute cost. Larger n_seeds keeps helping
+    stochastically but with diminishing returns; minimize=True is the
+    decisive lever and should rarely be turned off.
 
     Pipeline:
       1. Embed n_seeds conformers via nvmolkit ETKDG. A single

--- a/src/confsweeper.py
+++ b/src/confsweeper.py
@@ -442,6 +442,91 @@ def _energy_ranked_dedup(
     return centroids
 
 
+# RDKit's standard rotatable-bond SMARTS — single bonds, not in any ring,
+# between heavy atoms that are themselves not terminal (D=1) and not in
+# triple bonds. For cyclic peptides this matches side-chain rotations only;
+# the macrocycle backbone is in-ring and therefore excluded.
+_ROTATABLE_BOND_SMARTS = Chem.MolFromSmarts("[!$(*#*)&!D1]-&!@[!$(*#*)&!D1]")
+
+
+def _jitter_rotatable_dihedrals(
+    mol: Chem.Mol,
+    jitter_deg: float,
+    seed: int,
+) -> int:
+    """
+    Add uniform random rotation in [-jitter_deg, +jitter_deg] to each
+    rotatable-bond dihedral on every conformer attached to mol (in place).
+
+    Intended as a post-embedding diversifier: ETKDG's torsion-knowledge prior
+    biases initial coordinates toward known-favourable dihedrals, which can
+    leave it stuck in one basin even with thousands of seeds. A small random
+    perturbation per rotatable bond pushes some conformers across nearby
+    basin boundaries before MACE rescoring; combined with the energy filter
+    and energy-ranked dedup, this can recover basins that pure ETKDG misses.
+
+    Macrocycle backbone bonds are in-ring and not matched by the rotatable-
+    bond SMARTS, so this only perturbs side-chain rotamers on cyclic
+    peptides. To explore backbone dihedrals on macrocycles, use
+    `torsional_sampling.sample_constrained_confs` instead.
+
+    Params:
+        mol: rdkit.Chem.Mol : mol with conformers attached (modified in place)
+        jitter_deg: float : maximum absolute perturbation per dihedral in degrees;
+            sampled uniformly on [-jitter_deg, +jitter_deg] independently per
+            (conformer, dihedral) pair
+        seed: int : RNG seed; fully determines the perturbation given
+            identical input geometry
+    Returns:
+        int : number of rotatable dihedrals jittered per conformer (constant
+            across conformers for the same mol)
+    """
+    from rdkit.Chem import rdMolTransforms
+
+    matches = mol.GetSubstructMatches(_ROTATABLE_BOND_SMARTS)
+
+    # Build (i, j, k, l) atom-index quadruples once: j-k is the rotatable bond;
+    # i and l are the first heavy-atom neighbours other than the bond partner.
+    # Heavy-atom-only matters because the SMARTS still matches when Hs are
+    # explicit (methyl-CH3 carbons have degree 4, not D1), but rotating around a
+    # bond whose only off-partner neighbour is an H is geometrically degenerate
+    # — it just spins the H(s). Skipping such bonds keeps `n` aligned with the
+    # standard implicit-H rotatable-bond count.
+    dihedrals: list[tuple[int, int, int, int]] = []
+    for j, k in matches:
+        atom_j = mol.GetAtomWithIdx(j)
+        atom_k = mol.GetAtomWithIdx(k)
+        i = next(
+            (
+                n.GetIdx()
+                for n in atom_j.GetNeighbors()
+                if n.GetIdx() != k and n.GetAtomicNum() != 1
+            ),
+            None,
+        )
+        l = next(  # noqa: E741 — l is the standard fourth-atom name for dihedrals
+            (
+                n.GetIdx()
+                for n in atom_k.GetNeighbors()
+                if n.GetIdx() != j and n.GetAtomicNum() != 1
+            ),
+            None,
+        )
+        if i is None or l is None:
+            continue
+        dihedrals.append((i, j, k, l))
+
+    rng = np.random.default_rng(seed)
+    for cid in [c.GetId() for c in mol.GetConformers()]:
+        conf = mol.GetConformer(cid)
+        for i, j, k, l in dihedrals:
+            current = rdMolTransforms.GetDihedralDeg(conf, i, j, k, l)
+            delta = float(rng.uniform(-jitter_deg, jitter_deg))
+            rdMolTransforms.SetDihedralDeg(conf, i, j, k, l, current + delta)
+
+    return len(dihedrals)
+
+
 def get_mol_PE_exhaustive(
     smi: str,
     params,
@@ -453,6 +538,8 @@ def get_mol_PE_exhaustive(
     e_window_kT: float = 5.0,
     rmsd_threshold: float = 0.1,
     minimize: bool = False,
+    mmff_backend: str = "gpu",
+    dihedral_jitter_deg: float = 0.0,
     seed: int = 0,
 ) -> Tuple[Chem.Mol, List[int], List[float]]:
     """
@@ -477,11 +564,35 @@ def get_mol_PE_exhaustive(
          EmbedMolecules call is used when n_seeds <= embed_chunk_size; for
          larger n_seeds the call is repeated in chunks with seed offsets so
          the GPU memory footprint stays bounded.
-      2. Optional MMFF94 minimization in place (off by default).
-      3. MACE-score the full pool in chunks of score_chunk_size.
-      4. Drop conformers with (E - E_min) > e_window_kT * kT (kT = 26 meV at
+      2. Optional rotatable-bond dihedral jitter (off by default;
+         dihedral_jitter_deg > 0 enables). Adds uniform random rotation in
+         [-jitter, +jitter] to every rotatable-bond dihedral on every
+         conformer to push some conformers across nearby basin boundaries
+         before scoring. Excludes ring bonds, so on cyclic peptides this
+         only perturbs side-chain rotamers.
+      3. Optional MMFF94 minimization in place (off by default). Two backends:
+         'gpu' (default) calls nvmolkit.mmffOptimization.MMFFOptimizeMoleculesConfs
+         in a single batched CUDA pass — ~25-50× faster than 'cpu' on cyclic
+         peptides. 'cpu' calls RDKit's serial AllChem.MMFFOptimizeMolecule per
+         conformer; pick this only if you need bit-exact agreement with RDKit
+         reference behaviour or if nvmolkit is unavailable.
+
+         The two backends can disagree on the final geometry of any given
+         conformer — different BFGS gradient details push the optimizer into
+         neighbouring basins on a few percent of cases. Final-energy Pearson r
+         between backends is ~0.95 with ~3-5 kcal/mol per-conformer std on
+         cyclic peptides; the basin distribution after dedup is comparable
+         but not identical. For exhaustive ETKDG saturation runs the GPU
+         backend's stochasticity is acceptable because we care about basin
+         coverage in aggregate, not per-conformer reproducibility.
+
+         When both jitter and minimize are on, MMFF runs after jitter and
+         will tend to relax perturbed geometries back toward the original
+         basin.
+      4. MACE-score the full pool in chunks of score_chunk_size.
+      5. Drop conformers with (E - E_min) > e_window_kT * kT (kT = 26 meV at
          298 K). At least one conformer (the minimum) is always retained.
-      5. Energy-ranked geometric dedup via _energy_ranked_dedup, keeping the
+      6. Energy-ranked geometric dedup via _energy_ranked_dedup, keeping the
          lowest-energy member of each geometric basin defined by
          rmsd_threshold (normalised L1 units, matching get_mol_PE_batched).
 
@@ -503,7 +614,16 @@ def get_mol_PE_exhaustive(
         e_window_kT: float : energy filter window in units of kT_298K
         rmsd_threshold: float : geometric dedup exclusion radius (normalised L1)
         minimize: bool : MMFF94-minimize each conformer before scoring
-        seed: int : base ETKDG random seed; chunk i uses seed + i*embed_chunk_size
+        mmff_backend: str : 'gpu' (default; nvmolkit batched CUDA) or 'cpu'
+            (RDKit serial). Only consulted when minimize=True. See pipeline
+            step 3 above for behaviour notes.
+        dihedral_jitter_deg: float : maximum absolute rotation in degrees applied
+            uniformly at random to each rotatable-bond dihedral on every
+            conformer; 0.0 disables jitter (default)
+        seed: int : base ETKDG random seed; chunk i uses seed + i*embed_chunk_size.
+            The dihedral jitter RNG is also seeded from this value (with a
+            fixed offset) so two runs with identical params and seed produce
+            identical jitter patterns.
     Returns:
         rdkit.Chem.Mol : mol with only basin-representative conformers attached
         List[int] : conformer IDs of basin representatives, ordered by ascending energy
@@ -541,17 +661,41 @@ def get_mol_PE_exhaustive(
     if not all_conf_ids:
         return mol, [], []
 
-    # 2. Optional MMFF94 minimization. Errors leave the conformer at its
+    # 2. Optional rotatable-bond dihedral jitter. Mutates conformer geometry
+    # in place; uses a deterministic seed offset so the perturbation is
+    # reproducible from the function-level seed.
+    if dihedral_jitter_deg > 0.0:
+        _jitter_rotatable_dihedrals(
+            mol,
+            jitter_deg=dihedral_jitter_deg,
+            seed=seed
+            + 1_000_003,  # large prime offset to avoid clashing with chunked embed seeds
+        )
+
+    # 3. Optional MMFF94 minimization. Errors leave the conformer at its
     # pre-minimize geometry; we don't track per-conformer success/failure
     # because MACE scoring afterwards naturally surfaces any pathological
     # geometries through extreme energies.
     if minimize:
-        from rdkit.Chem import AllChem
+        if mmff_backend == "gpu":
+            # nvmolkit batched CUDA implementation — single call optimises
+            # every conformer of `mol` in place. Order-dependent import:
+            # nvmolkit.embedMolecules must be loaded first to register some
+            # global C++ state, which the embed call above already did.
+            from nvmolkit.mmffOptimization import MMFFOptimizeMoleculesConfs
 
-        for cid in all_conf_ids:
-            AllChem.MMFFOptimizeMolecule(mol, confId=cid)
+            MMFFOptimizeMoleculesConfs([mol], hardwareOptions=hardware_opts)
+        elif mmff_backend == "cpu":
+            from rdkit.Chem import AllChem
 
-    # 3. Batched MACE scoring, chunked to bound the GPU forward-pass batch size.
+            for cid in all_conf_ids:
+                AllChem.MMFFOptimizeMolecule(mol, confId=cid)
+        else:
+            raise ValueError(
+                f"unknown mmff_backend {mmff_backend!r}; expected 'gpu' or 'cpu'"
+            )
+
+    # 4. Batched MACE scoring, chunked to bound the GPU forward-pass batch size.
     atomic_nums = [a.GetAtomicNum() for a in mol.GetAtoms()]
     energies: List[float] = []
     for start in range(0, len(all_conf_ids), score_chunk_size):
@@ -567,7 +711,7 @@ def get_mol_PE_exhaustive(
 
     energies_arr = np.asarray(energies, dtype=np.float64)
 
-    # 4. Energy filter: keep conformers within e_window_kT * kT of the minimum.
+    # 5. Energy filter: keep conformers within e_window_kT * kT of the minimum.
     e_min = energies_arr.min()
     keep_mask = (energies_arr - e_min) <= e_window_kT * _KT_EV_298K
     if not keep_mask.any():
@@ -580,7 +724,7 @@ def get_mol_PE_exhaustive(
     kept_conf_ids = [all_conf_ids[i] for i in kept_pool_idx]
     kept_energies = energies_arr[kept_pool_idx]
 
-    # 5. Energy-ranked geometric dedup. With a single survivor there is
+    # 6. Energy-ranked geometric dedup. With a single survivor there is
     # nothing to cluster; otherwise use the basin-energy primitive.
     if len(kept_conf_ids) == 1:
         centroid_ids = list(kept_conf_ids)
@@ -595,7 +739,7 @@ def get_mol_PE_exhaustive(
         centroid_ids = [kept_conf_ids[i] for i in centroid_pool_idx]
         centroid_energies = [float(kept_energies[i]) for i in centroid_pool_idx]
 
-    # 6. Output: drop non-centroid conformers from the mol so the returned
+    # 7. Output: drop non-centroid conformers from the mol so the returned
     # object matches the (mol, ids, energies) contract used by callers of
     # get_mol_PE / get_mol_PE_batched.
     centroid_set = set(centroid_ids)

--- a/tests/test_confsweeper.py
+++ b/tests/test_confsweeper.py
@@ -76,16 +76,27 @@ def test_get_embed_params_macrocycle_14config_enabled():
     assert params.useMacrocycle14config is True
 
 
-def test_get_embed_params_macrocycle_small_ring_torsions_enabled():
+def test_get_embed_params_macrocycle_small_ring_torsions_disabled():
+    """useSmallRingTorsions is intentionally NOT enabled even though it
+    would help small rings inside the macrocycle scaffold: nvmolkit hangs
+    indefinitely in CPU preprocessing when the flag is set. See the
+    docstring of get_embed_params_macrocycle for the rationale."""
     params = get_embed_params_macrocycle()
-    assert params.useSmallRingTorsions is True
+    assert params.useSmallRingTorsions is False
 
 
-def test_get_embed_params_macrocycle_differs_from_default():
-    # useSmallRingTorsions is the key addition — off by default in ETKDGv3
+def test_get_embed_params_macrocycle_enables_macrocycle_torsion_flags():
+    """The macrocycle helper differs from the default in turning on the two
+    macrocycle-specific torsion flags. useSmallRingTorsions is left off in
+    both (see test_get_embed_params_macrocycle_small_ring_torsions_disabled)."""
     default = get_embed_params()
     macro = get_embed_params_macrocycle()
-    assert macro.useSmallRingTorsions != default.useSmallRingTorsions
+    assert macro.useMacrocycleTorsions is True
+    assert macro.useMacrocycle14config is True
+    # useMacrocycleTorsions defaults to True in ETKDGv3 too, so the helper's
+    # only behavioural difference vs get_embed_params is the explicit setting
+    # of these two flags (and the explicit useRandomCoords=True).
+    assert macro.useRandomCoords == default.useRandomCoords
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_exhaustive_etkdg.py
+++ b/tests/test_exhaustive_etkdg.py
@@ -10,6 +10,7 @@ from rdkit.Chem import AllChem
 from confsweeper import (
     _KT_EV_298K,
     _energy_ranked_dedup,
+    _jitter_rotatable_dihedrals,
     get_embed_params,
     get_mol_PE_exhaustive,
 )
@@ -295,9 +296,9 @@ def test_exhaustive_single_conformer_skips_dedup(exhaustive_mocks):
     assert mol.GetNumConformers() == 1
 
 
-def test_exhaustive_minimize_invokes_mmff(exhaustive_mocks):
-    """minimize=True triggers AllChem.MMFFOptimizeMolecule once per conformer
-    in the pool (called before energy scoring)."""
+def test_exhaustive_minimize_cpu_invokes_per_conformer_mmff(exhaustive_mocks):
+    """mmff_backend='cpu' triggers AllChem.MMFFOptimizeMolecule once per
+    conformer in the pool (called before energy scoring)."""
     n_seeds = 6
     with patch("rdkit.Chem.AllChem.MMFFOptimizeMolecule", return_value=0) as mock_mmff:
         get_mol_PE_exhaustive(
@@ -309,8 +310,184 @@ def test_exhaustive_minimize_invokes_mmff(exhaustive_mocks):
             embed_chunk_size=n_seeds,
             score_chunk_size=n_seeds,
             minimize=True,
+            mmff_backend="cpu",
             rmsd_threshold=0.0,
             e_window_kT=1e9,
         )
     # One MMFF call per embedded conformer. Mock embed always succeeds.
     assert mock_mmff.call_count == n_seeds
+
+
+def test_exhaustive_minimize_gpu_invokes_batched_mmff(exhaustive_mocks):
+    """mmff_backend='gpu' calls nvmolkit.mmffOptimization.MMFFOptimizeMoleculesConfs
+    exactly once with the full conformer set."""
+    n_seeds = 6
+    with patch(
+        "nvmolkit.mmffOptimization.MMFFOptimizeMoleculesConfs", return_value=[[]]
+    ) as mock_mmff:
+        get_mol_PE_exhaustive(
+            TEST_SMILES,
+            get_embed_params(),
+            hardware_opts=None,
+            calc=MagicMock(),
+            n_seeds=n_seeds,
+            embed_chunk_size=n_seeds,
+            score_chunk_size=n_seeds,
+            minimize=True,
+            mmff_backend="gpu",
+            rmsd_threshold=0.0,
+            e_window_kT=1e9,
+        )
+    # Single batched call regardless of n_seeds.
+    mock_mmff.assert_called_once()
+    args, kwargs = mock_mmff.call_args
+    # First positional arg is the list of mols (length 1, our test mol).
+    assert len(args[0]) == 1
+    assert args[0][0].GetNumConformers() == n_seeds
+
+
+def test_exhaustive_minimize_unknown_backend_raises(exhaustive_mocks):
+    """An unrecognised mmff_backend value raises ValueError."""
+    with pytest.raises(ValueError, match="unknown mmff_backend"):
+        get_mol_PE_exhaustive(
+            TEST_SMILES,
+            get_embed_params(),
+            hardware_opts=None,
+            calc=MagicMock(),
+            n_seeds=2,
+            embed_chunk_size=2,
+            score_chunk_size=2,
+            minimize=True,
+            mmff_backend="something_else",
+        )
+
+
+# ---------------------------------------------------------------------------
+# _jitter_rotatable_dihedrals
+# ---------------------------------------------------------------------------
+
+
+def _embed_butane(n_confs: int = 3, seed: int = 0):
+    """
+    Build n-butane (CCCC) with explicit Hs and CPU-embed `n_confs` conformers.
+    n-butane has exactly one rotatable dihedral (the central C-C bond), so the
+    output of `_jitter_rotatable_dihedrals` is unambiguous.
+
+    Params:
+        n_confs: int : number of conformers to embed
+        seed: int : RNG seed for ETKDG
+    Returns:
+        rdkit.Chem.Mol : n-butane mol with explicit Hs and `n_confs` conformers
+    """
+    from rdkit import Chem
+
+    mol = Chem.AddHs(Chem.MolFromSmiles("CCCC"))
+    AllChem.EmbedMultipleConfs(mol, numConfs=n_confs, randomSeed=seed)
+    return mol
+
+
+def test_jitter_rotatable_dihedrals_returns_dihedral_count():
+    """n-butane has exactly one rotatable backbone dihedral."""
+    mol = _embed_butane(n_confs=2)
+    n = _jitter_rotatable_dihedrals(mol, jitter_deg=10.0, seed=0)
+    assert n == 1
+
+
+def test_jitter_rotatable_dihedrals_changes_geometry():
+    """A non-zero jitter actually moves the dihedral; magnitude is bounded by
+    jitter_deg and direction is random per (conformer, dihedral)."""
+    from rdkit.Chem import rdMolTransforms
+
+    mol = _embed_butane(n_confs=4, seed=1)
+    # Capture original dihedrals (atom indices for n-butane: 0-1-2-3 are the carbons).
+    before = [
+        rdMolTransforms.GetDihedralDeg(mol.GetConformer(c), 0, 1, 2, 3)
+        for c in range(mol.GetNumConformers())
+    ]
+    _jitter_rotatable_dihedrals(mol, jitter_deg=15.0, seed=42)
+    after = [
+        rdMolTransforms.GetDihedralDeg(mol.GetConformer(c), 0, 1, 2, 3)
+        for c in range(mol.GetNumConformers())
+    ]
+    deltas = [(a - b + 180) % 360 - 180 for a, b in zip(after, before)]
+    # Every conformer moved (uniform sampling at jitter=15° draws zero with
+    # probability ≪ 1e-9 across 4 conformers).
+    assert all(abs(d) > 1e-3 for d in deltas)
+    # Every move stays inside the [-jitter, +jitter] envelope (with tiny tolerance
+    # for floating-point in the trig conversions).
+    assert all(abs(d) <= 15.0 + 1e-6 for d in deltas)
+
+
+def test_jitter_rotatable_dihedrals_seed_is_deterministic():
+    """Two jitter calls on identical inputs with the same seed produce
+    identical dihedrals; with different seeds they differ."""
+    from rdkit.Chem import rdMolTransforms
+
+    def _jitter_and_read(seed: int) -> list[float]:
+        mol = _embed_butane(n_confs=3, seed=7)
+        _jitter_rotatable_dihedrals(mol, jitter_deg=20.0, seed=seed)
+        return [
+            rdMolTransforms.GetDihedralDeg(mol.GetConformer(c), 0, 1, 2, 3)
+            for c in range(mol.GetNumConformers())
+        ]
+
+    a1 = _jitter_and_read(seed=99)
+    a2 = _jitter_and_read(seed=99)
+    b = _jitter_and_read(seed=100)
+    assert a1 == a2
+    assert a1 != b
+
+
+def test_jitter_rotatable_dihedrals_skips_ring_bonds():
+    """The rotatable-bond SMARTS uses '!@' to exclude ring bonds. Cyclohexane
+    therefore has zero rotatable bonds and the helper is a no-op."""
+    from rdkit import Chem
+
+    mol = Chem.AddHs(Chem.MolFromSmiles("C1CCCCC1"))
+    AllChem.EmbedMultipleConfs(mol, numConfs=2, randomSeed=0)
+    n = _jitter_rotatable_dihedrals(mol, jitter_deg=30.0, seed=0)
+    assert n == 0
+
+
+def test_get_mol_PE_exhaustive_jitter_zero_is_noop(exhaustive_mocks):
+    """dihedral_jitter_deg=0 must not invoke the jitter helper. The default
+    pipeline behaviour stays unchanged."""
+    with patch(
+        "confsweeper._jitter_rotatable_dihedrals", return_value=0
+    ) as mock_jitter:
+        get_mol_PE_exhaustive(
+            TEST_SMILES,
+            get_embed_params(),
+            hardware_opts=None,
+            calc=MagicMock(),
+            n_seeds=6,
+            embed_chunk_size=6,
+            score_chunk_size=6,
+            dihedral_jitter_deg=0.0,
+            rmsd_threshold=0.0,
+            e_window_kT=1e9,
+        )
+    mock_jitter.assert_not_called()
+
+
+def test_get_mol_PE_exhaustive_jitter_invokes_helper(exhaustive_mocks):
+    """dihedral_jitter_deg>0 invokes the jitter helper exactly once with the
+    matching jitter angle."""
+    with patch(
+        "confsweeper._jitter_rotatable_dihedrals", return_value=1
+    ) as mock_jitter:
+        get_mol_PE_exhaustive(
+            TEST_SMILES,
+            get_embed_params(),
+            hardware_opts=None,
+            calc=MagicMock(),
+            n_seeds=6,
+            embed_chunk_size=6,
+            score_chunk_size=6,
+            dihedral_jitter_deg=12.5,
+            rmsd_threshold=0.0,
+            e_window_kT=1e9,
+        )
+    mock_jitter.assert_called_once()
+    _, kwargs = mock_jitter.call_args
+    assert kwargs["jitter_deg"] == 12.5

--- a/tests/test_exhaustive_etkdg.py
+++ b/tests/test_exhaustive_etkdg.py
@@ -1,0 +1,120 @@
+"""Unit tests for the exhaustive ETKDG sampling primitives in src/confsweeper.py."""
+
+import numpy as np
+import pytest
+import torch
+
+from confsweeper import _energy_ranked_dedup
+
+
+def _line_coords(positions: list[float], n_atoms: int = 4) -> torch.Tensor:
+    """
+    Build [N, n_atoms, 3] coords where conformer i is a rigid translation of a
+    fixed atom layout by `positions[i]` along x. Pairwise normalised L1 distance
+    between conformer i and j equals |positions[i] - positions[j]|.
+
+    Params:
+        positions: list[float] : x-translation per conformer
+        n_atoms: int : number of atoms (constant across conformers)
+    Returns:
+        torch.Tensor [N, n_atoms, 3] of conformer coordinates
+    """
+    base = torch.zeros(n_atoms, 3)
+    base[:, 0] = torch.arange(n_atoms, dtype=torch.float32)
+    coords = torch.stack([base + torch.tensor([p, 0.0, 0.0]) for p in positions])
+    return coords
+
+
+# ---------------------------------------------------------------------------
+# _energy_ranked_dedup
+# ---------------------------------------------------------------------------
+
+
+def test_energy_ranked_dedup_empty():
+    coords = torch.zeros(0, 4, 3)
+    energies = np.zeros(0)
+    assert _energy_ranked_dedup(coords, energies, rmsd_threshold=0.1) == []
+
+
+def test_energy_ranked_dedup_single():
+    coords = torch.zeros(1, 4, 3)
+    energies = np.array([0.0])
+    assert _energy_ranked_dedup(coords, energies, rmsd_threshold=0.1) == [0]
+
+
+def test_energy_ranked_dedup_keeps_all_distinct():
+    """Three conformers spaced far apart in geometry should all survive dedup."""
+    coords = _line_coords([0.0, 5.0, 10.0])
+    energies = np.array([0.0, 1.0, 2.0])
+    centroids = _energy_ranked_dedup(coords, energies, rmsd_threshold=0.1)
+    assert sorted(centroids) == [0, 1, 2]
+
+
+def test_energy_ranked_dedup_collapses_all_close():
+    """Three conformers all within the RMSD threshold collapse to the lowest-energy."""
+    # All translations are 0.0, so pairwise normalised L1 distance = 0
+    coords = _line_coords([0.0, 0.0, 0.0])
+    energies = np.array([2.0, 0.5, 1.0])
+    centroids = _energy_ranked_dedup(coords, energies, rmsd_threshold=0.1)
+    assert centroids == [1]  # index of the lowest energy
+
+
+def test_energy_ranked_dedup_picks_lowest_energy_in_basin():
+    """The lowest-energy conformer of a basin must be the one returned, even
+    when a higher-energy conformer is geometrically nearer the centroid of
+    other already-selected representatives."""
+    # conformers 0 and 1 are geometric near-duplicates; conformer 0 has the
+    # higher energy, so dedup must drop conformer 0 and keep conformer 1.
+    coords = _line_coords([0.0, 0.05, 5.0])
+    energies = np.array([1.0, 0.0, 2.0])
+    centroids = _energy_ranked_dedup(coords, energies, rmsd_threshold=0.1)
+    # Lowest-energy basin rep (conformer 1) and the geometrically distant
+    # conformer 2 survive; the higher-energy near-duplicate (conformer 0) drops.
+    assert sorted(centroids) == [1, 2]
+
+
+def test_energy_ranked_dedup_centroid_order_is_energy_ascending():
+    """Returned centroid order must match ascending energy."""
+    coords = _line_coords([0.0, 5.0, 10.0])
+    energies = np.array([2.0, 0.5, 1.5])
+    centroids = _energy_ranked_dedup(coords, energies, rmsd_threshold=0.1)
+    assert centroids == [1, 2, 0]
+
+
+def test_energy_ranked_dedup_stable_on_energy_ties():
+    """When two conformers tie on energy, np.argsort(kind='stable') breaks the
+    tie by original index. The lower-index conformer is selected first and
+    excludes its near-duplicate twin."""
+    # conformers 0 and 1 are near-duplicates with identical energy
+    coords = _line_coords([0.0, 0.05, 5.0])
+    energies = np.array([1.0, 1.0, 2.0])
+    centroids = _energy_ranked_dedup(coords, energies, rmsd_threshold=0.1)
+    assert centroids == [0, 2]
+
+
+def test_energy_ranked_dedup_threshold_boundary():
+    """A pair right at the threshold is treated as overlapping (strict < not <=)
+    only when distance is *less than* the threshold. Distance exactly at the
+    threshold is considered distinct."""
+    # On _line_coords, normalised L1 distance between conformer 0 (offset 0)
+    # and conformer 1 (offset 0.4) over n_atoms=4 atoms is
+    # (4 * 0.4) / (3 * 4) = 0.1333...
+    coords = _line_coords([0.0, 0.4])
+    energies = np.array([0.0, 1.0])
+    # Threshold 0.2 > 0.133, so the second is excluded
+    assert _energy_ranked_dedup(coords, energies, rmsd_threshold=0.2) == [0]
+    # Threshold 0.1 < 0.133, so both survive
+    assert sorted(_energy_ranked_dedup(coords, energies, rmsd_threshold=0.1)) == [0, 1]
+
+
+@pytest.mark.parametrize("device", ["cpu"])
+def test_energy_ranked_dedup_device_independent(device):
+    """Algorithm output is identical regardless of which device coords live on.
+    GPU coverage is exercised in integration tests; this parametrisation makes
+    it easy to add 'cuda' once the helper is wired into the full pipeline."""
+    coords = _line_coords([0.0, 5.0, 0.05]).to(device)
+    energies = np.array([1.0, 2.0, 0.0])
+    centroids = _energy_ranked_dedup(coords, energies, rmsd_threshold=0.1)
+    # Lowest energy is conformer 2 (offset 0.05, near conformer 0). It excludes
+    # conformer 0; conformer 1 is far away and survives.
+    assert sorted(centroids) == [1, 2]

--- a/tests/test_exhaustive_etkdg.py
+++ b/tests/test_exhaustive_etkdg.py
@@ -1,10 +1,18 @@
 """Unit tests for the exhaustive ETKDG sampling primitives in src/confsweeper.py."""
 
+from unittest.mock import MagicMock, patch
+
 import numpy as np
 import pytest
 import torch
+from rdkit.Chem import AllChem
 
-from confsweeper import _energy_ranked_dedup
+from confsweeper import (
+    _KT_EV_298K,
+    _energy_ranked_dedup,
+    get_embed_params,
+    get_mol_PE_exhaustive,
+)
 
 
 def _line_coords(positions: list[float], n_atoms: int = 4) -> torch.Tensor:
@@ -118,3 +126,191 @@ def test_energy_ranked_dedup_device_independent(device):
     # Lowest energy is conformer 2 (offset 0.05, near conformer 0). It excludes
     # conformer 0; conformer 1 is far away and survives.
     assert sorted(centroids) == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# get_mol_PE_exhaustive
+# ---------------------------------------------------------------------------
+
+# Tripeptide cyclic-ish backbone — small enough that CPU ETKDG produces
+# distinct conformers reliably, large enough that the geometric dedup actually
+# discriminates basins.
+TEST_SMILES = "C[C@@H](N)C(=O)NCC(=O)NCC(=O)O"
+
+
+def _mock_embed_seed_aware(mols, params, confsPerMolecule, hardwareOptions):
+    """
+    CPU drop-in for nvmolkit.embedMolecules.EmbedMolecules.
+
+    Matches two behaviours of the real call that the chunked-embed loop relies
+    on: respects params.randomSeed (so chunked calls produce distinct
+    conformers) and appends to any existing conformer set rather than
+    replacing it (verified empirically against nvmolkit on a small peptide).
+    """
+    for m in mols:
+        AllChem.EmbedMultipleConfs(
+            m,
+            numConfs=confsPerMolecule,
+            randomSeed=params.randomSeed,
+            clearConfs=False,
+        )
+
+
+def _make_seq_mock_mace():
+    """
+    Return a `_mace_batch_energies` mock that yields a global monotone-increasing
+    energy sequence across calls. Conformer i (counted across all chunks) is
+    assigned energy i * 0.01 eV — about 0.39 kT_298K per step. This makes the
+    energy filter and dedup behaviour deterministic and easy to assert against.
+    """
+    counter = [0]
+
+    def _mock(_calc, ase_mols):
+        out = [(counter[0] + i) * 0.01 for i in range(len(ase_mols))]
+        counter[0] += len(ase_mols)
+        return out
+
+    return _mock
+
+
+@pytest.fixture
+def exhaustive_mocks():
+    """Patch nvmolkit embed and MACE scoring with deterministic CPU mocks."""
+    mock_mace = _make_seq_mock_mace()
+    with patch(
+        "confsweeper.embed.EmbedMolecules", side_effect=_mock_embed_seed_aware
+    ), patch("confsweeper._mace_batch_energies", side_effect=mock_mace):
+        yield
+
+
+def test_exhaustive_returns_centroids_and_energies(exhaustive_mocks):
+    """Smoke: pipeline returns aligned centroids + energies in ascending order."""
+    mol, centroid_ids, energies = get_mol_PE_exhaustive(
+        TEST_SMILES,
+        get_embed_params(),
+        hardware_opts=None,
+        calc=MagicMock(),
+        n_seeds=20,
+        embed_chunk_size=20,
+        score_chunk_size=20,
+        rmsd_threshold=0.0,  # disable geometric dedup so all energy-filtered survivors are returned
+    )
+    assert len(centroid_ids) > 0
+    assert len(centroid_ids) == len(energies)
+    # Energies are in ascending order (energy-ranked dedup guarantees this).
+    assert energies == sorted(energies)
+    # Mol contains exactly the centroid conformers — non-centroids are removed.
+    assert mol.GetNumConformers() == len(centroid_ids)
+
+
+def test_exhaustive_chunked_path_accumulates_full_pool(exhaustive_mocks):
+    """When n_seeds > embed_chunk_size, the chunked loop accumulates the full
+    requested pool size (modulo CPU embed failures, which our mock does not
+    induce). This validates the chunked-embed mechanics, not nvmolkit's
+    cross-call diversity (the semantics experiment in docs/ covers that)."""
+    n_seeds = 24
+    embed_chunk_size = 8
+    _, centroid_ids, _ = get_mol_PE_exhaustive(
+        TEST_SMILES,
+        get_embed_params(),
+        hardware_opts=None,
+        calc=MagicMock(),
+        n_seeds=n_seeds,
+        embed_chunk_size=embed_chunk_size,
+        score_chunk_size=64,
+        rmsd_threshold=0.0,
+        e_window_kT=1e9,  # disable energy filter so we can count the full pool
+    )
+    # With rmsd_threshold=0 and the energy filter disabled, every successfully-
+    # embedded conformer is its own centroid.
+    assert len(centroid_ids) == n_seeds
+
+
+def test_exhaustive_energy_filter_drops_high_energy(exhaustive_mocks):
+    """Conformers more than e_window_kT * kT above the minimum are dropped.
+
+    With monotone energies E_i = i * 0.01 eV and kT = 0.02568 eV at 298 K,
+    a window of e_window_kT=2.0 keeps E_i ≤ 2 * 0.02568 ≈ 0.0514 eV, i.e.
+    the first 6 conformers (i = 0..5).
+    """
+    n_seeds = 20
+    e_window_kT = 2.0
+    expected_kept = int(np.floor(e_window_kT * _KT_EV_298K / 0.01)) + 1
+
+    _, centroid_ids, energies = get_mol_PE_exhaustive(
+        TEST_SMILES,
+        get_embed_params(),
+        hardware_opts=None,
+        calc=MagicMock(),
+        n_seeds=n_seeds,
+        embed_chunk_size=n_seeds,
+        score_chunk_size=n_seeds,
+        e_window_kT=e_window_kT,
+        rmsd_threshold=0.0,  # isolate the energy filter from dedup
+    )
+    assert len(centroid_ids) == expected_kept
+    assert max(energies) - min(energies) <= e_window_kT * _KT_EV_298K + 1e-12
+
+
+def test_exhaustive_zero_conformers_safe():
+    """When embed returns 0 conformers, contract is (mol, [], []) — no crash,
+    no MACE call, no dedup attempt."""
+
+    def _embed_nothing(mols, params, confsPerMolecule, hardwareOptions):
+        return  # don't add any conformers
+
+    mock_mace = MagicMock()
+    with patch("confsweeper.embed.EmbedMolecules", side_effect=_embed_nothing), patch(
+        "confsweeper._mace_batch_energies", side_effect=mock_mace
+    ):
+        mol, centroid_ids, energies = get_mol_PE_exhaustive(
+            TEST_SMILES,
+            get_embed_params(),
+            hardware_opts=None,
+            calc=MagicMock(),
+            n_seeds=20,
+            embed_chunk_size=20,
+            score_chunk_size=20,
+        )
+    assert centroid_ids == []
+    assert energies == []
+    assert mol.GetNumConformers() == 0
+    mock_mace.assert_not_called()
+
+
+def test_exhaustive_single_conformer_skips_dedup(exhaustive_mocks):
+    """n_seeds=1 returns one centroid without invoking the dedup primitive
+    (which is unnecessary on a singleton pool)."""
+    mol, centroid_ids, energies = get_mol_PE_exhaustive(
+        TEST_SMILES,
+        get_embed_params(),
+        hardware_opts=None,
+        calc=MagicMock(),
+        n_seeds=1,
+        embed_chunk_size=1,
+        score_chunk_size=1,
+    )
+    assert len(centroid_ids) == 1
+    assert len(energies) == 1
+    assert mol.GetNumConformers() == 1
+
+
+def test_exhaustive_minimize_invokes_mmff(exhaustive_mocks):
+    """minimize=True triggers AllChem.MMFFOptimizeMolecule once per conformer
+    in the pool (called before energy scoring)."""
+    n_seeds = 6
+    with patch("rdkit.Chem.AllChem.MMFFOptimizeMolecule", return_value=0) as mock_mmff:
+        get_mol_PE_exhaustive(
+            TEST_SMILES,
+            get_embed_params(),
+            hardware_opts=None,
+            calc=MagicMock(),
+            n_seeds=n_seeds,
+            embed_chunk_size=n_seeds,
+            score_chunk_size=n_seeds,
+            minimize=True,
+            rmsd_threshold=0.0,
+            e_window_kT=1e9,
+        )
+    # One MMFF call per embedded conformer. Mock embed always succeeds.
+    assert mock_mmff.call_count == n_seeds

--- a/tests/test_exhaustive_etkdg.py
+++ b/tests/test_exhaustive_etkdg.py
@@ -176,11 +176,25 @@ def _make_seq_mock_mace():
 
 @pytest.fixture
 def exhaustive_mocks():
-    """Patch nvmolkit embed and MACE scoring with deterministic CPU mocks."""
+    """
+    Patch nvmolkit embed, MACE scoring, and GPU MMFF with deterministic CPU
+    mocks so integration tests run without a GPU and without depending on
+    nvmolkit's real CUDA paths.
+
+    GPU MMFF is patched as a no-op (it would otherwise be called from
+    `get_mol_PE_exhaustive` whenever minimize=True, which is now the default).
+    Tests that specifically exercise the MMFF dispatch path patch
+    `nvmolkit.mmffOptimization.MMFFOptimizeMoleculesConfs` themselves.
+    """
     mock_mace = _make_seq_mock_mace()
-    with patch(
-        "confsweeper.embed.EmbedMolecules", side_effect=_mock_embed_seed_aware
-    ), patch("confsweeper._mace_batch_energies", side_effect=mock_mace):
+    with (
+        patch("confsweeper.embed.EmbedMolecules", side_effect=_mock_embed_seed_aware),
+        patch("confsweeper._mace_batch_energies", side_effect=mock_mace),
+        patch(
+            "nvmolkit.mmffOptimization.MMFFOptimizeMoleculesConfs",
+            return_value=[[]],
+        ),
+    ):
         yield
 
 
@@ -360,6 +374,95 @@ def test_exhaustive_minimize_unknown_backend_raises(exhaustive_mocks):
             minimize=True,
             mmff_backend="something_else",
         )
+
+
+def test_exhaustive_minimize_false_skips_both_backends(exhaustive_mocks):
+    """minimize=False must not call MMFF on either backend, regardless of what
+    mmff_backend is set to. The mmff_backend value is only consulted when
+    minimize is True."""
+    n_seeds = 6
+    with (
+        patch("rdkit.Chem.AllChem.MMFFOptimizeMolecule", return_value=0) as mock_cpu,
+        patch(
+            "nvmolkit.mmffOptimization.MMFFOptimizeMoleculesConfs",
+            return_value=[[]],
+        ) as mock_gpu,
+    ):
+        get_mol_PE_exhaustive(
+            TEST_SMILES,
+            get_embed_params(),
+            hardware_opts=None,
+            calc=MagicMock(),
+            n_seeds=n_seeds,
+            embed_chunk_size=n_seeds,
+            score_chunk_size=n_seeds,
+            minimize=False,
+            mmff_backend="gpu",  # ignored when minimize=False
+            rmsd_threshold=0.0,
+            e_window_kT=1e9,
+        )
+    mock_cpu.assert_not_called()
+    mock_gpu.assert_not_called()
+
+
+def test_exhaustive_energy_filter_force_keeps_minimum(exhaustive_mocks):
+    """If every conformer's energy comparison evaluates to False (e.g. NaN
+    energies), the energy-filter guard force-retains a single conformer at
+    `argmin(energies)` so the contract "at least one centroid" holds.
+
+    This exercises the `if not keep_mask.any()` fallback in get_mol_PE_exhaustive.
+    """
+    n_seeds = 5
+
+    def _all_nan_mace(_calc, ase_mols):
+        # Every conformer scored as NaN. (energies - e_min) <= window then
+        # evaluates to all-False, triggering the forced-keep-minimum guard.
+        return [float("nan")] * len(ase_mols)
+
+    with patch("confsweeper._mace_batch_energies", side_effect=_all_nan_mace):
+        mol, centroid_ids, energies = get_mol_PE_exhaustive(
+            TEST_SMILES,
+            get_embed_params(),
+            hardware_opts=None,
+            calc=MagicMock(),
+            n_seeds=n_seeds,
+            embed_chunk_size=n_seeds,
+            score_chunk_size=n_seeds,
+            minimize=False,
+            rmsd_threshold=0.0,
+            e_window_kT=5.0,
+        )
+    # Forced-keep-minimum guarantees exactly one centroid even though no
+    # conformer passes the energy filter. The returned mol holds exactly that
+    # conformer and energies has length one.
+    assert len(centroid_ids) == 1
+    assert len(energies) == 1
+    assert mol.GetNumConformers() == 1
+
+
+def test_exhaustive_returned_mol_matches_centroid_ids(exhaustive_mocks):
+    """The returned mol contains exactly the conformers identified by
+    centroid_ids — no leftover non-centroid conformers and no centroid
+    pruned out. This is the cleanup contract for the final stage of the
+    pipeline."""
+    n_seeds = 12
+    mol, centroid_ids, _ = get_mol_PE_exhaustive(
+        TEST_SMILES,
+        get_embed_params(),
+        hardware_opts=None,
+        calc=MagicMock(),
+        n_seeds=n_seeds,
+        embed_chunk_size=n_seeds,
+        score_chunk_size=n_seeds,
+        minimize=False,
+        rmsd_threshold=0.0,
+        e_window_kT=1e9,
+    )
+    mol_conf_ids = sorted(c.GetId() for c in mol.GetConformers())
+    assert mol_conf_ids == sorted(centroid_ids)
+    # Every centroid_id must resolve to a real conformer on the mol.
+    for cid in centroid_ids:
+        mol.GetConformer(cid)  # raises if missing
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary/Issue
Closes #7. Adds `get_mol_PE_exhaustive`, a randomized-saturation conformer-generation pipeline that replaces CREST metadynamics with brute-force ETKDG seeds + GPU MMFF minimization, then dedups by basin energy minimum. Validates the design against CREMP CREST ensembles on five representative cyclic peptides spanning 27–103 heavy atoms: on `cremp_typical` (27 heavy) the new pipeline reproduces CREST's Boltzmann distribution to within sampling noise (max_bw 0.318 vs CREST 0.246). The PR ships the pipeline, the saturation experiments behind the production defaults, an energy-backend sanity check (MACE-OFF23 vs xtb GFN2 — Pearson r 0.991), and a controlled ablation that disambiguates an apparent regression observed in the saturation sweep on large peptides.

## Key Features + Dependencies
- Added `get_mol_PE_exhaustive` to `src/confsweeper.py`: nvmolkit ETKDG embed (chunked when needed) → optional dihedral jitter → optional MMFF94 minimization (GPU via nvmolkit by default, CPU via RDKit fallback) → batched MACE scoring → 5 kT energy filter → basin-energy-ranked geometric dedup. Same `(mol, conf_ids, energies)` return contract as the existing `get_mol_PE_batched`, so downstream consumers swap one call.
- Added `_energy_ranked_dedup` private helper: variant of Butina that picks the lowest-energy member of each geometric basin instead of the densest cluster centre. Same normalised L1 distance metric as the existing `get_mol_PE_batched` Butina, so the threshold parameter is directly comparable.
- Added `_jitter_rotatable_dihedrals` private helper: optional post-embed perturbation of rotatable-bond dihedrals. Off by default; the saturation experiments showed it provides no measurable BW benefit but the machinery is in place for future experiments with larger jitter or backbone-aware variants.
- Added `_KT_EV_298K` module constant alongside the existing `_KCAL_TO_EV`. Used by the energy filter and by the diagnostic scripts.
- Added a module-level docstring to `src/confsweeper.py` distinguishing the three pipeline functions (`get_mol_PE`, `get_mol_PE_batched`, `get_mol_PE_exhaustive`) and their use cases.
- Added `scripts/saturation_etkdg.py`: the Phase 2 saturation sweep runner. Selects representative peptides from CREMP and PAMPA, sweeps `n_seeds`, supports two ETKDG variants (`etkdgv3_macrocycle` and `etkdg_original`) and rotatable-bond jitter, and writes results row-by-row to a resume-safe CSV.
- Added `scripts/mace_vs_xtb.py`: side-by-side MACE-OFF23 vs xtb GFN2 single-point comparison on a fixed conformer pool. Used to rule MACE out as the cause of one-hot Boltzmann distributions; result was Pearson r=0.991 (energies) and r=0.983 (rank order), exonerating the energy backend.
- Added `scripts/minimize_ablation.py`: controlled experiment that embeds once and runs the no-minimize and minimize=True pipelines on the same pool. Resolved the apparent minimize=True regression on large peptides as an ETKDG-seed-luck artifact.
- Added `tests/test_exhaustive_etkdg.py` with 26 unit tests covering all pipeline stages: energy-ranked dedup edge cases, chunked-embed accumulation, energy-filter behaviour including the force-keep-minimum guard, MMFF dispatch on both backends, jitter helper, and contract checks on the returned mol.
- Updated `src/README.md` with a new section documenting `get_mol_PE_exhaustive`'s contract, the seven-stage pipeline, the parameter table, and four critical-parameter notes (bursty saturation, minimize=True requirement, GPU MMFF stochasticity).
- Added `docs/exhaustive_etkdg_plan.md` (~800 lines) — the working design document with the full Phase 0–5 plan, the nvmolkit ETKDG semantics findings, the saturation experiment results, the MACE-vs-xtb comparison, the controlled minimize ablation, and the production defaults derived from the data.
- Added `scripts/README.md` documenting all three diagnostic scripts and how they fit together.
- Fixed two pre-existing stale tests in `tests/test_confsweeper.py` that asserted `useSmallRingTorsions=True`. The flag was disabled in PR #6 because nvmolkit hangs in CPU preprocessing when it is set; the tests had been broken on main since that landed.

## Tests/Test Steps
- [ ] `pixi run pytest tests/test_exhaustive_etkdg.py -v` — all 26 unit tests pass in ~3 s, no GPU required.
- [ ] `pixi run pytest tests/ -v` — full repo test suite green (the previously-broken `useSmallRingTorsions` assertions are now fixed).
- [ ] Smoke run of `get_mol_PE_exhaustive` on a small cyclic peptide — verify it returns non-empty `(mol, ids, energies)` with energies in ascending order:
  ```python
  from confsweeper import get_embed_params_macrocycle, get_hardware_opts, get_mace_calc, get_mol_PE_exhaustive
  params = get_embed_params_macrocycle()
  hw = get_hardware_opts()
  calc = get_mace_calc()
  mol, ids, e = get_mol_PE_exhaustive("CC(C)C[C@@H]1NC(=O)CN(C)C(=O)[C@H](C)NC1=O", params, hw, calc, n_seeds=200)
  assert len(ids) == len(e) and e == sorted(e) and mol.GetNumConformers() == len(ids)
  ```
- [ ] `pixi run python scripts/saturation_etkdg.py --cremp_csv data/processed/cremp/validation_subset.csv --pampa_csv /home/sabari/peptide_electrostatics/data/fine_tune/CycPeptMPDB_PAMPA_deduped.csv --out_csv /tmp/sat_smoke.csv --n_seeds_grid 100,500` — runs end-to-end on all 5 peptides for the two smallest seed counts; verifies the resume mechanism and CSV schema.
- [ ] `pixi run python scripts/mace_vs_xtb.py --label smoke --smiles 'CC(C)C[C@@H]1NC(=O)CN(C)C(=O)[C@H](C)NC1=O' --n_seeds 50 --xtb_workers 4` — checks the energy-backend comparison runs end-to-end (subprocess pool, xtb energy parsing, BW summaries).
- [ ] `pixi run python scripts/minimize_ablation.py --peptides cremp_typical --n_seeds 200` — verifies the minimize-ablation script runs end-to-end on a small budget.
- [ ] Spot-check that `get_mol_PE_exhaustive` defaults match the saturation-validated values: `n_seeds=10000`, `minimize=True`, `mmff_backend='gpu'`, `e_window_kT=5.0`, `rmsd_threshold=0.1`.

## Story
Three findings drove the design and are worth recording.

**The macrocycle bias does not suppress diversity.** The first hypothesis after seeing one-hot Boltzmann distributions on cyclic peptides was that ETKDGv3's macrocycle torsion knowledge biases initial coords toward a single "physically reasonable" basin. Re-running the saturation grid with RDKit's 2015 `ETKDG()` (no macrocycle terms) showed the opposite: ETKDGv3 wins on three of five peptides, substantially on `cremp_typical` (best max_bw 0.222 vs 0.671) and `pampa_medium` (0.415 vs 0.939). The macrocycle prior helps because it concentrates random embeds in the geometrically plausible region of conformation space, raising the probability that any given low-energy basin lies inside the random-init's reach.

**MACE-OFF23 is not responsible for the one-hot ensembles.** A direct head-to-head against xtb GFN2 (the energy model CREST uses internally) on the same 1000-conformer pool of `pampa_large` showed Pearson r=0.991 between mean-shifted energies and r=0.983 between rank orders. Both backends pick the same conformer as the dominant one. xtb is actually *more* one-hot than MACE on this pool. Whatever causes the one-hot distributions, it is not the MACE energies — it is the conformer pool.

**MMFF94 minimization is the lever that turns ETKDG output into a real Boltzmann ensemble.** Without it, on `cremp_typical` n=10000 the pipeline returns 1 basin / max_bw=1.000. With it (CPU MMFF), 75 basins / max_bw=0.071 — better than CREMP's CREST-derived 0.246. The mechanism: ETKDG produces conformers near basin floors but not at them, so the energy filter and dedup mistake within-basin geometric noise for between-basin diversity. MMFF pulls each conformer to its true basin minimum, so the dedup output is real basin minima rather than noise. The saturation sweep showed an apparent regression on large peptides; a controlled ablation (same starting pool, varying only the minimize flag) showed that was an ETKDG-seed sampling-luck artifact and that minimize=True is the right global default.

**nvmolkit GPU MMFF is functional and ~25–50× faster than RDKit's CPU loop**, with Pearson r=0.95 between final energies and median per-conformer RMS coord delta of ~0.01 Å. The two backends sometimes find different local minima from the same starting point (a few percent of conformers), which is acceptable for basin-coverage in aggregate but not for bit-exact reproducibility. The default is GPU; CPU is available as a fallback for ablation studies.

## Related Issues / Branches
- Upstream: builds on PR #6 (`3-cremp-dataset-comparison` merge) which disabled the `useSmallRingTorsions` flag. Without that fix nvmolkit hangs indefinitely on cyclic peptides and none of this work runs.
- Downstream: a follow-up branch in `peptide_electrostatics` will swap `finetune_generate_conformers.py` to call `get_mol_PE_exhaustive` and re-run the PAMPA fine-tuning pipeline. The expectation, documented in `docs/exhaustive_etkdg_plan.md` Phase 5a, is that the learned `α` in `FinetuneJanossyWrapper` drifts toward 1 (from the current 0.01 hedge) and that val/MAE drops on the peptides where exhaustive ETKDG produces rich Boltzmann ensembles.
- Sibling: a separate non-ETKDG sampler benchmark is planned (Phase 5b), comparing against fast-CREST, replica-exchange MD, and torsional-sampling-at-scale on the same five representative peptides and the same MACE scoring path. Captured in the design doc as a follow-up; not part of this PR.

## Other Notes
- **Saturation defaults are saturation-validated**: `n_seeds=10000` was the smallest grid value that reliably broke `pampa_large` off one-hot in the saturation sweep, and `minimize=True` is the lever from the controlled ablation. They are not arbitrary; the design doc records the experiments that picked them.
- **Bursty saturation**: across every (peptide, mode, jitter) combination, `max_bw` did not smoothly decrease with `n_seeds` — it oscillates because each newly-discovered low-energy conformer resets `E_min`. Production callers should not interpret a single n_seeds run as the converged answer; the right summary metric across a saturation curve is `min(max_bw)`, not the value at any specific n_seeds. Documented in the README's critical-parameters section.
- **`pampa_large`-style peptides remain a sampling-coverage hard case** even with the new pipeline. Three out of four `pampa_large` runs in the controlled ablation produced near-one-hot results regardless of whether minimize was on. This is a sampling-coverage problem at the embedding stage, not a minimization problem; ETKDG simply doesn't generate enough basin diversity for some of the largest macrocycles. The downstream fine-tuning's α=0.01 init is the right hedge for that contingency.
- **GPU MMFF stochasticity**: per-conformer geometries from `mmff_backend='gpu'` are not bit-exact identical to `'cpu'` (Pearson r ≈ 0.95). Both are valid descents to local minima; just non-identical local minima. For exhaustive saturation runs the disagreement is acceptable. For comparison studies that demand bit-exactness against RDKit reference behaviour, switch to `'cpu'` and accept the 25–50× slowdown.
- **`useSmallRingTorsions` is and will remain disabled**: nvmolkit hangs in CPU preprocessing when it is set. The previously-broken stale tests asserting the flag was on are now updated to assert the correct disabled state.
- **Diagnostic scripts and data files**: `scripts/{saturation_etkdg,mace_vs_xtb,minimize_ablation}.py` are research tools, not library code. Their outputs (`data/processed/saturation/*.csv`, `scripts/*.log`) are gitignored so the repo doesn't fill with experimental run artifacts. The script source code and READMEs are tracked.